### PR TITLE
fix: don't update the package.json version before npm stage

### DIFF
--- a/packages/d2-app/src/commands/scripts/release.js
+++ b/packages/d2-app/src/commands/scripts/release.js
@@ -4,10 +4,19 @@ const path = require('path')
 const semanticRelease = require('semantic-release')
 const getWorkspacePackages = require('./support/getWorkspacePackages')
 
+const packageIsPublishable = pkgJsonPath => {
+    try {
+        const pkgJson = require(pkgJsonPath)
+        return !!pkgJson.name && !pkgJson.private
+    } catch (e) {
+        return false
+    }
+}
+
 function publisher(target = '', packages) {
     switch (target.toLowerCase()) {
         case 'npm': {
-            return packages.map(pkgJsonPath => {
+            return packages.filter(packageIsPublishable).map(pkgJsonPath => {
                 return [
                     '@semantic-release/npm',
                     {
@@ -95,6 +104,7 @@ const handler = async ({ publish }) => {
             GIT_AUTHOR_EMAIL: 'ci@dhis2.org',
             GIT_COMMITTER_NAME: '@dhis2-bot',
             GIT_COMMITTER_EMAIL: 'ci@dhis2.org',
+            NPM_CONFIG_ALLOW_SAME_VERSION: 'true', // Ensure we still publish even though we've already updated the pacakge versions
         },
     }
 

--- a/packages/d2-app/src/commands/scripts/release.js
+++ b/packages/d2-app/src/commands/scripts/release.js
@@ -4,19 +4,10 @@ const path = require('path')
 const semanticRelease = require('semantic-release')
 const getWorkspacePackages = require('./support/getWorkspacePackages')
 
-const packageIsPublishable = pkgJsonPath => {
-    try {
-        const pkgJson = require(pkgJsonPath)
-        return !!pkgJson.name && !pkgJson.private
-    } catch (e) {
-        return false
-    }
-}
-
 function publisher(target = '', packages) {
     switch (target.toLowerCase()) {
         case 'npm': {
-            return packages.filter(packageIsPublishable).map(pkgJsonPath => {
+            return packages.map(pkgJsonPath => {
                 return [
                     '@semantic-release/npm',
                     {

--- a/packages/d2-app/src/commands/scripts/support/semantic-release-update-deps.js
+++ b/packages/d2-app/src/commands/scripts/support/semantic-release-update-deps.js
@@ -48,7 +48,7 @@ const prepare = (config, context) => {
     if (!context.packages) {
         verifyConditions({ ...config, silent: true }, context)
     }
-    const { silent, exact } = config
+    const { silent, exact, updatePackageVersion = false } = config
     const { nextRelease, logger, packages } = context
 
     const targetVersion = exact
@@ -59,6 +59,17 @@ const prepare = (config, context) => {
     packages.forEach(package => {
         const pkgJson = package.json
         const relativePath = path.relative(context.cwd, package.path)
+
+        if (updatePackageVersion) {
+            pkgJson.version = nextRelease.version
+            if (!silent) {
+                logger.log(
+                    `Updated version to ${nextRelease.version} for package ${
+                        package.label
+                    } at ${relativePath}`
+                )
+            }
+        }
 
         replaceDependencies(
             pkgJson,

--- a/packages/d2-app/src/commands/scripts/support/semantic-release-update-deps.js
+++ b/packages/d2-app/src/commands/scripts/support/semantic-release-update-deps.js
@@ -60,15 +60,6 @@ const prepare = (config, context) => {
         const pkgJson = package.json
         const relativePath = path.relative(context.cwd, package.path)
 
-        pkgJson.version = nextRelease.version
-        if (!silent) {
-            logger.log(
-                `Updated version to ${nextRelease.version} for package ${
-                    package.label
-                } at ${relativePath}`
-            )
-        }
-
         replaceDependencies(
             pkgJson,
             ['dependencies', 'devDependencies', 'peerDependencies'],

--- a/packages/d2-app/src/commands/scripts/support/semantic-release-update-deps.js
+++ b/packages/d2-app/src/commands/scripts/support/semantic-release-update-deps.js
@@ -48,7 +48,7 @@ const prepare = (config, context) => {
     if (!context.packages) {
         verifyConditions({ ...config, silent: true }, context)
     }
-    const { silent, exact, updatePackageVersion = false } = config
+    const { silent, exact, updatePackageVersion = true } = config
     const { nextRelease, logger, packages } = context
 
     const targetVersion = exact


### PR DESCRIPTION
Pass `NPM_CONFIG_ALLOW_SAME_VERSION` to `npm publish` so it doesn't fail when we've already updated the package.json version in the updateDeps plugin.