### PR TITLE
chore: update tab spacing when updating package.json

### DIFF
--- a/packages/d2-app/src/commands/scripts/support/semantic-release-update-deps.js
+++ b/packages/d2-app/src/commands/scripts/support/semantic-release-update-deps.js
@@ -48,7 +48,7 @@ const prepare = (config, context) => {
     if (!context.packages) {
         verifyConditions({ ...config, silent: true }, context)
     }
-    const { silent, exact } = config
+    const { silent, exact, tabSpaces = 4 } = config
     const { nextRelease, logger, packages } = context
 
     const targetVersion = exact
@@ -85,7 +85,7 @@ const prepare = (config, context) => {
         )
         fs.writeFileSync(
             package.path,
-            JSON.stringify(pkgJson, undefined, config.tabSpaces || 2) + '\n'
+            JSON.stringify(pkgJson, undefined, tabSpaces) + '\n'
         )
     })
 }


### PR DESCRIPTION
This is a non-functional change to keep `package.json` files from bouncing back and forth between 2 and 4-space tabs when updated manually (using cli-style settings) and automatically.