### PR TITLE
fix: seed from file variable name was misspelled

### DIFF
--- a/packages/cluster/src/db.js
+++ b/packages/cluster/src/db.js
@@ -15,7 +15,7 @@ const downloadDatabase = async ({ cache, path, v, update, url }) => {
                     v
                 )}, use --update to re-download`
             )
-            dbFile = cache.getCacheLocation(cacheName)
+            return cache.getCacheLocation(cacheName)
         } else {
             const dbUrl = url.replace(/{version}/g, v)
             reporter.info(
@@ -36,7 +36,7 @@ const downloadDatabase = async ({ cache, path, v, update, url }) => {
     }
 }
 
-const seedFromFile = async ({ cacheLocation, file, v }) => {
+const seedFromFile = async ({ cacheLocation, dbFile, v }) => {
     reporter.info(`Seeding database (this may take some time)...`)
     reporter.debug(`Seeding from database dump ${chalk.bold(dbFile)}`)
 


### PR DESCRIPTION
This fixes a silly typo which caused the command `d2 cluster up <version> --seed --seedFile <dbFile>` to fail with an undeclared variable exception.  Bummed we didn't catch it before 1.0, but 1.0.1 pre-announcement should be ok.

The earlier `dbFile =` hid this bug when the database was downloaded, rather than local, because `dbFile` was I guess implicitly defined by the assignment?  I didn't even know you could do that...