### PR TITLE
feat: support official docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 script:
     - echo "Smoke testing d2 executable"
     - ./packages/main/bin/d2 debug system
+    - yarn test
 deploy:
     - provider: script
       skip_cleanup: true

--- a/package.json
+++ b/package.json
@@ -12,12 +12,16 @@
     "license": "BSD-3-Clause",
     "devDependencies": {
         "@dhis2/cli-style": "3.2.2",
-        "husky": "^2.0.0"
+        "husky": "^2.0.0",
+        "tape": "^4.10.1"
     },
     "husky": {
         "hooks": {
             "commit-msg": "d2-style commit check",
             "pre-commit": "d2-style js apply"
         }
+    },
+    "scripts": {
+        "test": "tape packages/**/tests/*.js"
     }
 }

--- a/packages/cluster/src/commands/down.js
+++ b/packages/cluster/src/commands/down.js
@@ -1,11 +1,7 @@
 const chalk = require('chalk')
 const path = require('path')
 const { exec, reporter } = require('@dhis2/cli-helpers-engine')
-const {
-    initDockerComposeCache,
-    makeComposeProject,
-    makeDockerImage,
-} = require('../common')
+const { initDockerComposeCache, makeComposeProject } = require('../common')
 
 const defaults = require('../defaults')
 

--- a/packages/cluster/src/commands/logs.js
+++ b/packages/cluster/src/commands/logs.js
@@ -1,11 +1,7 @@
 const chalk = require('chalk')
 const path = require('path')
 const { reporter, exec, tryCatchAsync } = require('@dhis2/cli-helpers-engine')
-const {
-    initDockerComposeCache,
-    makeComposeProject,
-    makeDockerImage,
-} = require('../common')
+const { initDockerComposeCache, makeComposeProject } = require('../common')
 const defaults = require('../defaults')
 
 const run = async function({ service, name, ...argv }) {

--- a/packages/cluster/src/commands/restart.js
+++ b/packages/cluster/src/commands/restart.js
@@ -1,11 +1,7 @@
 const chalk = require('chalk')
 const path = require('path')
 const { reporter, exec, tryCatchAsync } = require('@dhis2/cli-helpers-engine')
-const {
-    initDockerComposeCache,
-    makeComposeProject,
-    makeDockerImage,
-} = require('../common')
+const { initDockerComposeCache, makeComposeProject } = require('../common')
 
 const defaults = require('../defaults')
 

--- a/packages/cluster/src/commands/restart.js
+++ b/packages/cluster/src/commands/restart.js
@@ -49,9 +49,10 @@ module.exports = {
     builder: {
         port: {
             alias: 'p',
-            desc: 'Specify the port on which to expose the DHIS2 instance',
+            desc: `Specify the port on which to expose the DHIS2 instance (default: ${
+                defaults.port
+            })`,
             type: 'integer',
-            default: defaults.port,
         },
     },
     handler: run,

--- a/packages/cluster/src/commands/seed.js
+++ b/packages/cluster/src/commands/seed.js
@@ -41,7 +41,6 @@ module.exports = {
         dhis2Version: {
             desc: 'DHIS2 version to use',
             type: 'string',
-            default: '',
         },
     },
     handler: run,

--- a/packages/cluster/src/commands/up.js
+++ b/packages/cluster/src/commands/up.js
@@ -44,7 +44,7 @@ const run = async function(argv) {
     if (seed || seedFile) {
         await doSeed({
             cacheLocation,
-            dbVersion: resolvedDatabaseVersion,
+            dbVersion: runtime.DHIS2_CORE_DB_VERSION,
             name,
             path: seedFile,
             update,

--- a/packages/cluster/src/commands/up.js
+++ b/packages/cluster/src/commands/up.js
@@ -11,28 +11,14 @@ const defaults = require('../defaults')
 const { seed: doSeed } = require('../db')
 
 const run = async function(argv) {
-    const {
-        cluster,
-        name,
-        port,
-        seed,
-        seedFile,
-        update,
-        image,
-        dhis2Version,
-        dbVersion,
-        customContext,
-        variant,
-        channel,
-    } = argv
+    const { cluster, name, seed, seedFile, update } = argv
 
     const runtime = makeEnvironment(argv, {}, cluster)
 
     const cacheLocation = await initDockerComposeCache({
         cache: argv.getCache(),
         dockerComposeRepository:
-            argv.cluster.dockerComposeRepository ||
-            defaults.dockerComposeRepository,
+            cluster.dockerComposeRepository || defaults.dockerComposeRepository,
         force: update,
     })
 

--- a/packages/cluster/src/commands/up.js
+++ b/packages/cluster/src/commands/up.js
@@ -83,7 +83,9 @@ module.exports = {
     builder: {
         port: {
             alias: 'p',
-            desc: 'Specify the port on which to expose the DHIS2 instance',
+            desc: `Specify the port on which to expose the DHIS2 instance (default: ${
+                defaults.port
+            })`,
             type: 'integer',
         },
         seed: {
@@ -115,7 +117,7 @@ module.exports = {
             type: 'string',
         },
         channel: {
-            desc: 'Set the release channel to use',
+            desc: 'Set the release channel to use (default: stable)',
             type: 'string',
         },
         customContext: {

--- a/packages/cluster/src/commands/up.js
+++ b/packages/cluster/src/commands/up.js
@@ -103,7 +103,8 @@ module.exports = {
             type: 'string',
         },
         channel: {
-            desc: 'Set the release channel to use (default: stable)',
+            desc:
+                'Set the release channel to use (default: ${defaults.stable})',
             type: 'string',
         },
         customContext: {

--- a/packages/cluster/src/commands/up.js
+++ b/packages/cluster/src/commands/up.js
@@ -103,8 +103,9 @@ module.exports = {
             type: 'string',
         },
         channel: {
-            desc:
-                'Set the release channel to use (default: ${defaults.stable})',
+            desc: `Set the release channel to use (default: ${
+                defaults.channel
+            })`,
             type: 'string',
         },
         customContext: {

--- a/packages/cluster/src/commands/up.js
+++ b/packages/cluster/src/commands/up.js
@@ -125,7 +125,7 @@ module.exports = {
         },
         variant: {
             desc: 'Append variant options to the image',
-            type: 'array',
+            type: 'string',
         },
     },
     handler: run,

--- a/packages/cluster/src/common.js
+++ b/packages/cluster/src/common.js
@@ -116,7 +116,7 @@ module.exports.makeEnvironment = (argv = {}, cache = {}, config = {}) => {
         DHIS2_CORE_PORT: resolvedPort,
     }
 
-    reporter.info('Runtime environment\n', env)
+    reporter.debug('Runtime environment\n', env)
 
     return env
 }

--- a/packages/cluster/src/common.js
+++ b/packages/cluster/src/common.js
@@ -74,7 +74,7 @@ module.exports.makeEnvironment = (argv = {}, cache = {}, config = {}) => {
 
     // resolve specials...
     const resolvedDhis2Version = resolved.dhis2Version || name
-    const resolvedDatabaseVersion = resolved.dbVersion || name
+    const resolvedDatabaseVersion = resolved.dbVersion || resolvedDhis2Version
     const resolvedContextPath = resolved.customContext ? `/${name}` : ''
 
     const dockerImage = makeDockerImage(

--- a/packages/cluster/src/common.js
+++ b/packages/cluster/src/common.js
@@ -1,5 +1,7 @@
 const { reporter } = require('@dhis2/cli-helpers-engine')
 
+const defaults = require('./defaults')
+
 const dockerComposeCacheName = 'd2-cluster-docker-compose-v2'
 
 module.exports.initDockerComposeCache = async ({
@@ -37,11 +39,7 @@ module.exports.makeComposeProject = version => `d2-cluster-${version}`
 module.exports.substituteVersion = (string, version) =>
     replacer(string, 'version', version)
 
-module.exports.makeDockerImage = (
-    string = '',
-    substitutes = {},
-    variants = []
-) => {
+const makeDockerImage = (string = '', substitutes = {}, variants = []) => {
     let res = string
 
     // the stable channel is just dhis2/core, so if the channel is
@@ -70,4 +68,59 @@ function replacer(string, token, value) {
     return string.replace(regexp, value)
 }
 
+module.exports.makeEnvironment = (argv = {}, cache = {}, config = {}) => {
+    // resolve version for dhis2 and db
+    const resolvedDhis2Version =
+        argv.dhis2Version ||
+        cache.dhis2Version ||
+        config.dhis2Version ||
+        argv.name
+    const resolvedDatabaseVersion =
+        argv.dbVersion ||
+        cache.dbVersion ||
+        config.dbVersion ||
+        resolvedDhis2Version ||
+        argv.name
+
+    // resolve the docker image
+    const resolvedChannel =
+        argv.channel || cache.channel || config.channel || defaults.channel
+    const resolvedImage =
+        argv.image || cache.image || config.image || defaults.image
+    const resolvedVariant = argv.variant || cache.variant || config.variant
+
+    const resolvedDockerImage = makeDockerImage(
+        resolvedImage,
+        {
+            channel: resolvedChannel,
+            version: resolvedDhis2Version,
+        },
+        resolvedVariant
+    )
+
+    // resolve runtime port and context
+    const resolvedPort = argv.port || cache.port || config.port || defaults.port
+    const resolvedContext =
+        argv.customContext ||
+        cache.customContext ||
+        config.customContext ||
+        defaults.customContext
+    const resolvedContextPath = resolvedContext ? `/${argv.name}` : ''
+
+    const env = {
+        DHIS2_CORE_NAME: argv.name,
+        DHIS2_CORE_CONTEXT_PATH: resolvedContextPath,
+        DHIS2_CORE_IMAGE: resolvedDockerImage,
+        DHIS2_CORE_VERSION: resolvedDhis2Version,
+        DHIS2_CORE_DB_VERSION: resolvedDatabaseVersion,
+        DHIS2_CORE_PORT: resolvedPort,
+    }
+
+    reporter.info('Runtime environment\n', env)
+
+    return env
+}
+
 module.exports.getLocalClusters = async () => {}
+
+module.exports.makeDockerImage = makeDockerImage

--- a/packages/cluster/src/common.js
+++ b/packages/cluster/src/common.js
@@ -98,7 +98,6 @@ module.exports.makeEnvironment = (argv = {}, cache = {}, config = {}) => {
         DHIS2_CORE_NAME: cfg.name,
         DHIS2_CORE_IMAGE: cfg.dockerImage,
         DHIS2_CORE_CONTEXT_PATH: cfg.contextPath,
-
         DHIS2_CORE_VERSION: cfg.dhis2Version,
         DHIS2_CORE_DB_VERSION: cfg.dbVersion,
         DHIS2_CORE_PORT: cfg.port,

--- a/packages/cluster/src/defaults.js
+++ b/packages/cluster/src/defaults.js
@@ -1,6 +1,7 @@
 module.exports = {
     dhis2Version: '',
-    image: 'amcgee/dhis2-core:{version}-alpine',
+    channel: '',
+    image: 'dhis2/core{channel}:{version}',
     port: 8080,
     customContext: false,
     update: false,

--- a/packages/cluster/src/defaults.js
+++ b/packages/cluster/src/defaults.js
@@ -1,7 +1,7 @@
 module.exports = {
     dhis2Version: '',
     dbVersion: '',
-    channel: '',
+    channel: 'stable',
     image: 'dhis2/core{channel}:{version}',
     port: 8080,
     customContext: false,

--- a/packages/cluster/src/defaults.js
+++ b/packages/cluster/src/defaults.js
@@ -1,5 +1,6 @@
 module.exports = {
     dhis2Version: '',
+    dbVersion: '',
     channel: '',
     image: 'dhis2/core{channel}:{version}',
     port: 8080,

--- a/packages/cluster/src/index.js
+++ b/packages/cluster/src/index.js
@@ -3,9 +3,10 @@ const { namespace } = require('@dhis2/cli-helpers-engine')
 const command = namespace('cluster', {
     desc: 'Manage DHIS2 Docker clusters',
     aliases: 'c',
-    builder: yargs => {
-        yargs.commandDir('commands')
-    },
+    builder: yargs =>
+        yargs.commandDir('commands').parserConfiguration({
+            'parse-numbers': false,
+        }),
 })
 
 module.exports = command

--- a/packages/cluster/tests/setup-environment.js
+++ b/packages/cluster/tests/setup-environment.js
@@ -1,0 +1,26 @@
+const test = require('tape')
+
+const { makeEnvironment } = require('../src/common.js')
+
+test('build runtime environment based on defaults', function(t) {
+    t.plan(1)
+
+    const argv = {
+        name: 'dev',
+    }
+    const cache = {}
+    const config = {}
+
+    const actual = makeEnvironment(argv, cache, config)
+
+    const expected = {
+        DHIS2_CORE_NAME: 'dev',
+        DHIS2_CORE_CONTEXT_PATH: '',
+        DHIS2_CORE_IMAGE: 'dhis2/core:dev',
+        DHIS2_CORE_VERSION: 'dev',
+        DHIS2_CORE_DB_VERSION: 'dev',
+        DHIS2_CORE_PORT: 8080,
+    }
+
+    t.deepEqual(actual, expected, 'default environment')
+})

--- a/packages/cluster/tests/setup-environment.js
+++ b/packages/cluster/tests/setup-environment.js
@@ -2,6 +2,8 @@ const test = require('tape')
 
 const { makeEnvironment } = require('../src/common.js')
 
+const defaults = require('../src/defaults.js')
+
 test('build runtime environment based on defaults', function(t) {
     t.plan(1)
 
@@ -19,7 +21,7 @@ test('build runtime environment based on defaults', function(t) {
         DHIS2_CORE_IMAGE: 'dhis2/core:dev',
         DHIS2_CORE_VERSION: 'dev',
         DHIS2_CORE_DB_VERSION: 'dev',
-        DHIS2_CORE_PORT: 8080,
+        DHIS2_CORE_PORT: defaults.port,
     }
 
     t.deepEqual(actual, expected, 'default environment')
@@ -48,6 +50,37 @@ test('build runtime environment based on args', function(t) {
         DHIS2_CORE_IMAGE: 'dhis2/core-canary:2.33-jetty-slackware',
         DHIS2_CORE_VERSION: '2.33',
         DHIS2_CORE_DB_VERSION: '2.32',
+        DHIS2_CORE_PORT: 8233,
+    }
+
+    t.deepEqual(actual, expected, 'default environment')
+})
+
+test('build runtime environment based on mixed args and config', function(t) {
+    t.plan(1)
+
+    const argv = {
+        name: 'mydev',
+        customContext: true,
+    }
+
+    const cache = {}
+
+    const config = {
+        dhis2Version: 'master',
+        port: 8233,
+        channel: 'dev',
+        dbVersion: 'dev',
+    }
+
+    const actual = makeEnvironment(argv, cache, config)
+
+    const expected = {
+        DHIS2_CORE_NAME: 'mydev',
+        DHIS2_CORE_CONTEXT_PATH: '/mydev',
+        DHIS2_CORE_IMAGE: 'dhis2/core-dev:master',
+        DHIS2_CORE_VERSION: 'master',
+        DHIS2_CORE_DB_VERSION: 'dev',
         DHIS2_CORE_PORT: 8233,
     }
 

--- a/packages/cluster/tests/setup-environment.js
+++ b/packages/cluster/tests/setup-environment.js
@@ -24,3 +24,32 @@ test('build runtime environment based on defaults', function(t) {
 
     t.deepEqual(actual, expected, 'default environment')
 })
+
+test('build runtime environment based on args', function(t) {
+    t.plan(1)
+
+    const argv = {
+        name: 'dev',
+        customContext: true,
+        dhis2Version: '2.33',
+        dbVersion: '2.32',
+        channel: 'canary',
+        variant: ['jetty', 'slackware'],
+        port: 8233,
+    }
+    const cache = {}
+    const config = {}
+
+    const actual = makeEnvironment(argv, cache, config)
+
+    const expected = {
+        DHIS2_CORE_NAME: 'dev',
+        DHIS2_CORE_CONTEXT_PATH: '/dev',
+        DHIS2_CORE_IMAGE: 'dhis2/core-canary:2.33-jetty-slackware',
+        DHIS2_CORE_VERSION: '2.33',
+        DHIS2_CORE_DB_VERSION: '2.32',
+        DHIS2_CORE_PORT: 8233,
+    }
+
+    t.deepEqual(actual, expected, 'default environment')
+})

--- a/packages/cluster/tests/setup-environment.js
+++ b/packages/cluster/tests/setup-environment.js
@@ -53,7 +53,7 @@ test('build runtime environment based on args', function(t) {
         DHIS2_CORE_PORT: 8233,
     }
 
-    t.deepEqual(actual, expected, 'default environment')
+    t.deepEqual(actual, expected, 'args environment')
 })
 
 test('build runtime environment based on mixed args and config', function(t) {
@@ -84,5 +84,36 @@ test('build runtime environment based on mixed args and config', function(t) {
         DHIS2_CORE_PORT: 8233,
     }
 
-    t.deepEqual(actual, expected, 'default environment')
+    t.deepEqual(actual, expected, 'args and config environment')
+})
+
+test('build runtime environment based on mixed args, cache, config and defaults', function(t) {
+    t.plan(1)
+
+    const argv = {
+        name: 'mydev',
+    }
+
+    const cache = {
+        customContext: true,
+        image: 'dhis2/core-canary:master-20190523-alpine',
+    }
+
+    const config = {
+        port: 8233,
+        dhis2Version: 'dev',
+    }
+
+    const actual = makeEnvironment(argv, cache, config)
+
+    const expected = {
+        DHIS2_CORE_NAME: 'mydev',
+        DHIS2_CORE_CONTEXT_PATH: '/mydev',
+        DHIS2_CORE_IMAGE: 'dhis2/core-canary:master-20190523-alpine',
+        DHIS2_CORE_VERSION: 'dev',
+        DHIS2_CORE_DB_VERSION: 'dev',
+        DHIS2_CORE_PORT: 8233,
+    }
+
+    t.deepEqual(actual, expected, 'merged environment')
 })

--- a/packages/cluster/tests/setup-environment.js
+++ b/packages/cluster/tests/setup-environment.js
@@ -36,7 +36,7 @@ test('build runtime environment based on args', function(t) {
         dhis2Version: '2.33',
         dbVersion: '2.32',
         channel: 'canary',
-        variant: ['jetty', 'slackware'],
+        variant: 'jetty-slackware',
         port: 8233,
     }
     const cache = {}

--- a/packages/cluster/tests/substitute-string-keys.js
+++ b/packages/cluster/tests/substitute-string-keys.js
@@ -1,0 +1,179 @@
+const test = require('tape')
+
+const { makeDockerImage, substituteVersion } = require('../src/common.js')
+
+const defaults = require('../src/defaults')
+
+const template = defaults.image
+
+test('replace {version} key with a value', function(t) {
+    t.plan(1)
+
+    const string = 'somethingwitha{version}key'
+    const version = '2.31.1'
+
+    const result = substituteVersion(string, version)
+
+    t.equal(result, 'somethingwitha2.31.1key', 'replace {version} with 2.31.1')
+})
+
+test('stable and 2.31.4', function(t) {
+    t.plan(2)
+
+    const expected = 'dhis2/core:2.31.4'
+
+    t.equal(
+        makeDockerImage(template, {
+            version: '2.31.4',
+            channel: 'stable',
+        }),
+        expected,
+        expected
+    )
+
+    t.equal(
+        makeDockerImage(template, {
+            version: '2.31.4',
+        }),
+        expected,
+        expected
+    )
+})
+
+test('stable and 2.32.0 with alpine variant', function(t) {
+    t.plan(1)
+
+    const expected = 'dhis2/core:2.32.0-alpine'
+
+    t.equal(
+        makeDockerImage(
+            template,
+            {
+                version: '2.32.0',
+            },
+            ['alpine']
+        ),
+        expected,
+        expected
+    )
+})
+
+test('stable and master with tomcat9 and debian-slim variant', function(t) {
+    t.plan(1)
+
+    const expected = 'dhis2/core:master-tomcat9-debian-slim'
+
+    t.equal(
+        makeDockerImage(
+            template,
+            {
+                version: 'master',
+            },
+            ['tomcat9', 'debian-slim']
+        ),
+        expected,
+        expected
+    )
+})
+
+test('stable and 2.32.0', function(t) {
+    t.plan(2)
+
+    const expected = 'dhis2/core:2.32.0'
+
+    t.equal(
+        makeDockerImage(template, {
+            version: '2.32.0',
+            channel: 'stable',
+        }),
+        expected,
+        expected
+    )
+
+    t.equal(
+        makeDockerImage(template, {
+            version: '2.32.0',
+        }),
+        expected,
+        expected
+    )
+})
+
+test('dev and master', function(t) {
+    t.plan(1)
+
+    const expected = 'dhis2/core-dev:master'
+
+    t.equal(
+        makeDockerImage(template, {
+            version: 'master',
+            channel: 'dev',
+        }),
+        expected,
+        expected
+    )
+})
+
+test('dev and 2.32', function(t) {
+    t.plan(1)
+
+    const expected = 'dhis2/core-dev:2.32'
+
+    t.equal(
+        makeDockerImage(template, {
+            version: '2.32',
+            channel: 'dev',
+        }),
+        expected,
+        expected
+    )
+})
+
+test('canary and master', function(t) {
+    t.plan(1)
+
+    const expected = 'dhis2/core-canary:master'
+
+    t.equal(
+        makeDockerImage(template, {
+            version: 'master',
+            channel: 'canary',
+        }),
+        expected,
+        expected
+    )
+})
+
+test('canary and 2.32', function(t) {
+    t.plan(1)
+
+    const expected = 'dhis2/core-canary:2.32'
+
+    t.equal(
+        makeDockerImage(template, {
+            version: '2.32',
+            channel: 'canary',
+        }),
+        expected,
+        expected
+    )
+})
+
+test('canary and 2.32 from date', function(t) {
+    t.plan(1)
+
+    const expected = 'dhis2/core-canary:2.32-20190523'
+
+    t.equal(
+        makeDockerImage(
+            template,
+            {
+                version: '2.32',
+                channel: 'canary',
+            },
+            ['20190523']
+        ),
+        expected,
+        expected
+    )
+})

--- a/packages/cluster/tests/substitute-string-keys.js
+++ b/packages/cluster/tests/substitute-string-keys.js
@@ -51,7 +51,7 @@ test('stable and 2.32.0 with alpine variant', function(t) {
             {
                 version: '2.32.0',
             },
-            ['alpine']
+            'alpine'
         ),
         expected,
         expected
@@ -69,7 +69,7 @@ test('stable and master with tomcat9 and debian-slim variant', function(t) {
             {
                 version: 'master',
             },
-            ['tomcat9', 'debian-slim']
+            'tomcat9-debian-slim'
         ),
         expected,
         expected
@@ -171,7 +171,7 @@ test('canary and 2.32 from date', function(t) {
                 version: '2.32',
                 channel: 'canary',
             },
-            ['20190523']
+            '20190523'
         ),
         expected,
         expected

--- a/yarn.lock
+++ b/yarn.lock
@@ -1256,6 +1256,11 @@ decompress-response@^3.3.0:
   dependencies:
     mimic-response "^1.0.0"
 
+deep-equal@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
+  integrity sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=
+
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
@@ -1278,6 +1283,13 @@ defer-to-connect@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.0.2.tgz#4bae758a314b034ae33902b5aac25a8dd6a8633e"
 
+define-properties@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
+  dependencies:
+    object-keys "^1.0.12"
+
 define-property@^0.2.5:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
@@ -1296,6 +1308,11 @@ define-property@^2.0.2:
   dependencies:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
+
+defined@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
+  integrity sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -1432,6 +1449,27 @@ error-ex@^1.3.1:
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
   dependencies:
     is-arrayish "^0.2.1"
+
+es-abstract@^1.5.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
+  integrity sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==
+  dependencies:
+    es-to-primitive "^1.2.0"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    is-callable "^1.1.4"
+    is-regex "^1.0.4"
+    object-keys "^1.0.12"
+
+es-to-primitive@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
+  integrity sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==
+  dependencies:
+    is-callable "^1.1.4"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.2"
 
 es6-promise@^4.0.3:
   version "4.2.6"
@@ -1714,6 +1752,13 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+for-each@~0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
+  integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
+  dependencies:
+    is-callable "^1.1.3"
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -1801,6 +1846,11 @@ fstream@^1.0.0, fstream@^1.0.12:
     inherits "~2.0.0"
     mkdirp ">=0.5 0"
     rimraf "2"
+
+function-bind@^1.0.2, function-bind@^1.1.1, function-bind@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
@@ -1906,7 +1956,7 @@ glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
 
-glob@^7.0.3, glob@^7.1.1:
+glob@^7.0.3, glob@^7.1.1, glob@~7.1.3:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
   dependencies:
@@ -2016,6 +2066,11 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
 
+has-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
+  integrity sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=
+
 has-unicode@^2.0.0, has-unicode@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
@@ -2050,6 +2105,13 @@ has-values@^1.0.0:
 has-yarn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/has-yarn/-/has-yarn-2.1.0.tgz#137e11354a7b5bf11aa5cb649cf0c6f3ff2b2e77"
+
+has@^1.0.1, has@^1.0.3, has@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
+  dependencies:
+    function-bind "^1.1.1"
 
 hook-std@^2.0.0:
   version "2.0.0"
@@ -2255,6 +2317,11 @@ is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
 
+is-callable@^1.1.3, is-callable@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
+  integrity sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
+
 is-ci@^1.0.10:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.2.1.tgz#e3779c8ee17fccf428488f6e281187f2e632841c"
@@ -2284,6 +2351,11 @@ is-data-descriptor@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
   dependencies:
     kind-of "^6.0.0"
+
+is-date-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+  integrity sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -2396,6 +2468,13 @@ is-redirect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
 
+is-regex@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  integrity sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=
+  dependencies:
+    has "^1.0.1"
+
 is-retry-allowed@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
@@ -2407,6 +2486,13 @@ is-stream@^1.0.0, is-stream@^1.1.0:
 is-subset@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
+
+is-symbol@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.2.tgz#a055f6ae57192caee329e7a860118b497a950f38"
+  integrity sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==
+  dependencies:
+    has-symbols "^1.0.0"
 
 is-text-path@^1.0.0:
   version "1.0.1"
@@ -3023,7 +3109,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.3, minimist@^1.2.0:
+minimist@^1.1.3, minimist@^1.2.0, minimist@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -3448,6 +3534,16 @@ object-copy@^0.1.0:
     copy-descriptor "^0.1.0"
     define-property "^0.2.5"
     kind-of "^3.0.3"
+
+object-inspect@~1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b"
+  integrity sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==
+
+object-keys@^1.0.12:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
+  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -4128,6 +4224,13 @@ resolve@^1.10.0:
   dependencies:
     path-parse "^1.0.6"
 
+resolve@~1.10.0:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.1.tgz#664842ac960795bbe758221cdccda61fb64b5f18"
+  integrity sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==
+  dependencies:
+    path-parse "^1.0.6"
+
 responselike@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/responselike/-/responselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7"
@@ -4140,6 +4243,13 @@ restore-cursor@^2.0.0:
   dependencies:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
+
+resumer@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/resumer/-/resumer-0.0.0.tgz#f1e8f461e4064ba39e82af3cdc2a8c893d076759"
+  integrity sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=
+  dependencies:
+    through "~2.3.4"
 
 ret@~0.1.10:
   version "0.1.15"
@@ -4538,6 +4648,15 @@ string-width@^3.0.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
+string.prototype.trim@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz#d04de2c89e137f4d7d206f086b5ed2fae6be8cea"
+  integrity sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.5.0"
+    function-bind "^1.0.2"
+
 string_decoder@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.2.0.tgz#fe86e738b19544afe70469243b2a1ee9240eae8d"
@@ -4614,6 +4733,25 @@ table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
+tape@^4.10.1:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/tape/-/tape-4.10.1.tgz#f73be60888dcb120f08b57f947af65a829506a5f"
+  integrity sha512-G0DywYV1jQeY3axeYnXUOt6ktnxS9OPJh97FGR3nrua8lhWi1zPflLxcAHavZ7Jf3qUfY7cxcVIVFa4mY2IY1w==
+  dependencies:
+    deep-equal "~1.0.1"
+    defined "~1.0.0"
+    for-each "~0.3.3"
+    function-bind "~1.1.1"
+    glob "~7.1.3"
+    has "~1.0.3"
+    inherits "~2.0.3"
+    minimist "~1.2.0"
+    object-inspect "~1.6.0"
+    resolve "~1.10.0"
+    resumer "~0.0.0"
+    string.prototype.trim "~1.1.2"
+    through "~2.3.8"
+
 tar@^2.0.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.2.tgz#0ca8848562c7299b8b446ff6a4d60cdbb23edc40"
@@ -4655,7 +4793,7 @@ through2@^2.0.0, through2@^2.0.2, through2@~2.0.0:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
-through@2, "through@>=2.2.7 <3", through@^2.3.6:
+through@2, "through@>=2.2.7 <3", through@^2.3.6, through@~2.3.4, through@~2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 


### PR DESCRIPTION
Started with the `makeDockerImage` resolutions for supporting channels and versions from https://hub.docker.com/u/dhis2.

- Adds support for official dhis2 docker images in different channels (`core`, `core-dev`, `core-canary`)
- Adds `--db-version <string>`
- Adds `--variant <array>` 
- Adds `--channel <string>`
- Adds tests for configuration merging and generating docker image names

#### Combos

```bash
# 2.32 works for both dhis2 and db version
d2 cluster up 2.32 \
  --channel canary

# custom images require explicit context
d2 cluster up custom \
  --image amcgee/dhis2-core:dev-alpine \
  --db-version 2.32 \ 
  --seed

# sometimes the dhis2 and db versions do not match
d2 cluster up stable \
  --dhis2-version 2.31.4 \
  --db-version 2.30 \
  --seed

# dhis2 version can be used for db version if it matches
d2 cluster up 232-dev \
  --channel dev \
  --dhis2-version 2.32 \
  --seed
```

#### Save per cluster configuration

To allow for subsequent startups without all the switches we need a mechanism (e.g. https://github.com/dhis2/cli/pull/53) to save the configuration first passed to the `up` command.

So first time the cluster is created it stores the config in e.g. `~/.cache/d2/d2-cluster/dev/configCache.json`

This enables:

```bash
d2 cluster up dev \
  --custom-context \
  --channel dev \
  --dhis2-version master \
  --db-version dev \
  --seed

d2 cluster down dev

d2 cluster up dev
# will use the `configCache`
```

Mentioning it here to note that implementing that is out of scope for this PR, but there are plans to do it.