### PR TITLE
fix: use dhis2/docker-compose instead of amcgee/dhis2-backend as default

### DIFF
--- a/packages/cluster/src/commands/down.js
+++ b/packages/cluster/src/commands/down.js
@@ -10,10 +10,14 @@ const {
 const defaults = require('../defaults')
 
 const run = async function({ name, clean, getCache, cluster, ...argv }) {
-    const { dockerComposeRepository } = resolveConfiguration(argv, {}, cluster)
+    const {
+        dockerComposeRepository,
+        dockerComposeDirectory,
+    } = resolveConfiguration(argv, {}, cluster)
     const cacheLocation = await initDockerComposeCache({
         cache: getCache(),
         dockerComposeRepository,
+        dockerComposeDirectory,
         force: false,
     })
 

--- a/packages/cluster/src/commands/logs.js
+++ b/packages/cluster/src/commands/logs.js
@@ -9,10 +9,14 @@ const {
 const defaults = require('../defaults')
 
 const run = async function({ service, name, cluster, ...argv }) {
-    const { dockerComposeRepository } = resolveConfiguration(argv, {}, cluster)
+    const {
+        dockerComposeRepository,
+        dockerComposeDirectory,
+    } = resolveConfiguration(argv, {}, cluster)
     const cacheLocation = await initDockerComposeCache({
         cache: argv.getCache(),
         dockerComposeRepository,
+        dockerComposeDirectory,
         force: false,
     })
     if (!cacheLocation) {

--- a/packages/cluster/src/commands/restart.js
+++ b/packages/cluster/src/commands/restart.js
@@ -10,10 +10,14 @@ const {
 const defaults = require('../defaults')
 
 const run = async function({ service, name, port, cluster, ...argv }) {
-    const { dockerComposeRepository } = resolveConfiguration(argv, {}, cluster)
+    const {
+        dockerComposeRepository,
+        dockerComposeDirectory,
+    } = resolveConfiguration(argv, {}, cluster)
     const cacheLocation = await initDockerComposeCache({
         cache: argv.getCache(),
         dockerComposeRepository,
+        dockerComposeDirectory,
         force: false,
     })
     if (!cacheLocation) {

--- a/packages/cluster/src/commands/seed.js
+++ b/packages/cluster/src/commands/seed.js
@@ -6,15 +6,16 @@ const defaults = require('../defaults')
 
 const run = async function({ dhis2Version, ...argv }) {
     const { cluster } = argv
-    const { dockerComposeRepository, dbVersion } = resolveConfiguration(
-        argv,
-        {},
-        cluster
-    )
+    const {
+        dockerComposeRepository,
+        dockerComposeDirectory,
+        dbVersion,
+    } = resolveConfiguration(argv, {}, cluster)
 
     const cacheLocation = await initDockerComposeCache({
         cache: argv.getCache(),
         dockerComposeRepository,
+        dockerComposeDirectory,
         force: false,
     })
 

--- a/packages/cluster/src/commands/up.js
+++ b/packages/cluster/src/commands/up.js
@@ -18,6 +18,7 @@ const run = async function(argv) {
     const cacheLocation = await initDockerComposeCache({
         cache: argv.getCache(),
         dockerComposeRepository: cfg.dockerComposeRepository,
+        dockerComposeDirectory: cfg.dockerComposeDirectory,
         force: update,
     })
 

--- a/packages/cluster/src/defaults.js
+++ b/packages/cluster/src/defaults.js
@@ -7,6 +7,7 @@ module.exports = {
     customContext: false,
     update: false,
     seed: false,
+    dockerComposeDirectory: 'cluster',
     dockerComposeRepository:
         'https://github.com/dhis2/docker-compose/archive/master.tar.gz',
     demoDatabaseURL:

--- a/packages/cluster/src/defaults.js
+++ b/packages/cluster/src/defaults.js
@@ -8,7 +8,7 @@ module.exports = {
     update: false,
     seed: false,
     dockerComposeRepository:
-        'https://github.com/amcgee/dhis2-backend/archive/master.tar.gz',
+        'https://github.com/dhis2/docker-compose/archive/master.tar.gz',
     demoDatabaseURL:
         'https://github.com/dhis2/dhis2-demo-db/blob/master/sierra-leone/{version}/dhis2-db-sierra-leone.sql.gz?raw=true',
 }


### PR DESCRIPTION
I forked https://github.com/amcgee/dhis2-backend to https://github.com/dhis2/docker-compose as I figure it's time for the Docker Compose setup to be under the official org on GitHub.

This PR updates the configuration default to the DHIS2 docker-compose repo.