### PR TITLE
fix: avoid double parsing of arguments

### DIFF
--- a/packages/app/bin/d2-app
+++ b/packages/app/bin/d2-app
@@ -5,4 +5,4 @@ const pkgJson = require('../package.json')
 const command = require(`..`)
 
 notifyOfUpdates(pkgJson)
-makeEntryPoint(command).parse()
+makeEntryPoint(command)

--- a/packages/cluster/bin/d2-cluster
+++ b/packages/cluster/bin/d2-cluster
@@ -5,4 +5,4 @@ const pkgJson = require('../package.json')
 const command = require(`..`)
 
 notifyOfUpdates(pkgJson)
-makeEntryPoint(command).parse()
+makeEntryPoint(command)

--- a/packages/create-app/bin/d2-create-app
+++ b/packages/create-app/bin/d2-create-app
@@ -5,4 +5,4 @@ const pkgJson = require('../package.json')
 const command = require(`..`)
 
 notifyOfUpdates(pkgJson)
-makeEntryPoint(command).parse()
+makeEntryPoint(command)

--- a/packages/create/bin/d2-create
+++ b/packages/create/bin/d2-create
@@ -5,4 +5,4 @@ const pkgJson = require('../package.json')
 const command = require(`..`)
 
 notifyOfUpdates(pkgJson)
-makeEntryPoint(command).parse()
+makeEntryPoint(command)

--- a/packages/create/templates/cli/bin/{{executable}}
+++ b/packages/create/templates/cli/bin/{{executable}}
@@ -5,4 +5,4 @@ const pkgJson = require('../package.json')
 const command = require(`..`)
 
 notifyOfUpdates(pkgJson)
-makeEntryPoint(command).parse()
+makeEntryPoint(command)

--- a/packages/main/bin/d2
+++ b/packages/main/bin/d2
@@ -5,4 +5,4 @@ const pkgJson = require('../package.json')
 const command = require(`..`)
 
 notifyOfUpdates(pkgJson)
-makeEntryPoint(command).parse()
+makeEntryPoint(command)

--- a/packages/utils/bin/d2-utils
+++ b/packages/utils/bin/d2-utils
@@ -5,4 +5,4 @@ const pkgJson = require('../package.json')
 const command = require(`..`)
 
 notifyOfUpdates(pkgJson)
-makeEntryPoint(command).parse()
+makeEntryPoint(command)


### PR DESCRIPTION
Stand-alone PR for avoiding double parsing of arguments with yargs leading to some strange bugs.