### PR TITLE
feat: add cluster db commands, update images on up, add compose cmd

### DIFF
--- a/packages/cluster/src/commands/compose.js
+++ b/packages/cluster/src/commands/compose.js
@@ -1,0 +1,51 @@
+const path = require('path')
+const { reporter, exec, tryCatchAsync } = require('@dhis2/cli-helpers-engine')
+const {
+    initDockerComposeCache,
+    makeComposeProject,
+    makeEnvironment,
+    resolveConfiguration,
+} = require('../common')
+
+const run = async function(argv) {
+    const { name, service, args } = argv
+    const cfg = await resolveConfiguration(argv)
+
+    const cacheLocation = await initDockerComposeCache({
+        composeProjectName: name,
+        cache: argv.getCache(),
+        dockerComposeRepository: cfg.dockerComposeRepository,
+        dockerComposeDirectory: cfg.dockerComposeDirectory,
+        force: false,
+    })
+    if (!cacheLocation) {
+        reporter.error('Failed to initialize cache...')
+        process.exit(1)
+    }
+    const res = await tryCatchAsync(
+        'exec(docker-compose)',
+        exec({
+            cmd: 'docker-compose',
+            args: [
+                '-p',
+                makeComposeProject(name),
+                '-f',
+                path.join(cacheLocation, 'docker-compose.yml'),
+                ...args,
+            ].concat(service ? [service] : []),
+            env: makeEnvironment(cfg),
+            pipe: true,
+        })
+    )
+    if (res.err) {
+        reporter.error('Failed to run docker-compose command')
+        process.exit(1)
+    }
+}
+
+module.exports = {
+    command: 'compose <name> [args...]',
+    desc: 'Run arbitrary docker-compose commands against a DHIS2 cluster',
+    aliases: 'c',
+    handler: run,
+}

--- a/packages/cluster/src/commands/compose.js
+++ b/packages/cluster/src/commands/compose.js
@@ -54,7 +54,8 @@ const run = async function(argv) {
 
 module.exports = {
     command: 'compose <name>',
-    desc: 'Run arbitrary docker-compose commands against a DHIS2 cluster',
+    desc:
+        'Run arbitrary docker-compose commands against a DHIS2 cluster.\nNOTE: pass -- after <name>',
     aliases: 'c',
     handler: run,
 }

--- a/packages/cluster/src/commands/db.js
+++ b/packages/cluster/src/commands/db.js
@@ -1,0 +1,11 @@
+const { namespace } = require('@dhis2/cli-helpers-engine')
+
+const command = namespace('db', {
+    desc: 'Manage the database in a DHIS2 Docker cluster',
+    builder: yargs =>
+        yargs.commandDir('db_cmds').parserConfiguration({
+            'parse-numbers': false,
+        }),
+})
+
+module.exports = command

--- a/packages/cluster/src/commands/db_cmds/backup.js
+++ b/packages/cluster/src/commands/db_cmds/backup.js
@@ -1,4 +1,4 @@
-const { reporter } = require('@dhis2/cli-helpers-engine')
+const { reporter, tryCatchAsync } = require('@dhis2/cli-helpers-engine')
 const { initDockerComposeCache, resolveConfiguration } = require('../../common')
 const { backup } = require('../../helpers/db')
 
@@ -20,12 +20,21 @@ const run = async function(argv) {
         process.exit(1)
     }
 
-    return await backup({
-        name,
-        cacheLocation,
-        path,
-        fat,
-    })
+    const res = await tryCatchAsync(
+        'db::backup',
+        backup({
+            name,
+            cacheLocation,
+            path,
+            fat,
+        })
+    )
+
+    if (res.err) {
+        reporter.error('Failed to backup database')
+        reporter.debugErr(res.err)
+        process.exit(1)
+    }
 }
 
 module.exports = {

--- a/packages/cluster/src/commands/db_cmds/backup.js
+++ b/packages/cluster/src/commands/db_cmds/backup.js
@@ -1,9 +1,9 @@
 const { reporter } = require('@dhis2/cli-helpers-engine')
-const { initDockerComposeCache, resolveConfiguration } = require('../common')
-const { restore } = require('../helpers/db')
+const { initDockerComposeCache, resolveConfiguration } = require('../../common')
+const { backup } = require('../../helpers/db')
 
 const run = async function(argv) {
-    const { name, getCache } = argv
+    const { name, getCache, path, fat } = argv
 
     const cfg = await resolveConfiguration(argv)
 
@@ -20,27 +20,22 @@ const run = async function(argv) {
         process.exit(1)
     }
 
-    return await restore({
+    return await backup({
+        name,
         cacheLocation,
-        dbVersion: cfg.dbVersion,
-        url: cfg.demoDatabaseURL,
-        ...argv,
+        path,
+        fat,
     })
 }
 
 module.exports = {
-    command: 'seed <name> [path]',
-    desc: false, // Deprecated, so hide from help
+    command: 'backup <name> <path>',
+    desc: 'Backup the database to a file',
     builder: {
-        update: {
-            alias: '-u',
+        fat: {
             desc: 'Force re-download of cached files',
             type: 'boolean',
             default: false,
-        },
-        dbVersion: {
-            desc: 'Version of the Database dump to use',
-            type: 'string',
         },
     },
     handler: run,

--- a/packages/cluster/src/commands/db_cmds/restore.js
+++ b/packages/cluster/src/commands/db_cmds/restore.js
@@ -1,4 +1,4 @@
-const { reporter } = require('@dhis2/cli-helpers-engine')
+const { reporter, tryCatchAsync } = require('@dhis2/cli-helpers-engine')
 const { initDockerComposeCache, resolveConfiguration } = require('../../common')
 const { restore } = require('../../helpers/db')
 
@@ -20,12 +20,21 @@ const run = async function(argv) {
         process.exit(1)
     }
 
-    return await restore({
-        cacheLocation,
-        dbVersion: cfg.dbVersion,
-        url: cfg.demoDatabaseURL,
-        ...argv,
-    })
+    const rest = await tryCatchAsync(
+        'db::restore',
+        restore({
+            cacheLocation,
+            dbVersion: cfg.dbVersion,
+            url: cfg.demoDatabaseURL,
+            ...argv,
+        })
+    )
+
+    if (res.err) {
+        reporter.error('Failed to restore database')
+        reporter.debugErr(res.err)
+        process.exit(1)
+    }
 }
 
 module.exports = {

--- a/packages/cluster/src/commands/db_cmds/restore.js
+++ b/packages/cluster/src/commands/db_cmds/restore.js
@@ -1,6 +1,6 @@
 const { reporter } = require('@dhis2/cli-helpers-engine')
-const { initDockerComposeCache, resolveConfiguration } = require('../common')
-const { restore } = require('../helpers/db')
+const { initDockerComposeCache, resolveConfiguration } = require('../../common')
+const { restore } = require('../../helpers/db')
 
 const run = async function(argv) {
     const { name, getCache } = argv
@@ -29,11 +29,11 @@ const run = async function(argv) {
 }
 
 module.exports = {
-    command: 'seed <name> [path]',
-    desc: false, // Deprecated, so hide from help
+    command: 'restore <name> [path]',
+    desc: 'Restore the database from a backup',
     builder: {
         update: {
-            alias: '-u',
+            alias: 'u',
             desc: 'Force re-download of cached files',
             type: 'boolean',
             default: false,

--- a/packages/cluster/src/commands/logs.js
+++ b/packages/cluster/src/commands/logs.js
@@ -56,6 +56,6 @@ const run = async function(argv) {
 module.exports = {
     command: 'logs <name> [service]',
     desc: 'Tail the logs from a given service',
-    aliases: 'r',
+    aliases: 'l',
     handler: run,
 }

--- a/packages/cluster/src/commands/up.js
+++ b/packages/cluster/src/commands/up.js
@@ -31,7 +31,7 @@ const run = async function(argv) {
 
     if (update) {
         reporter.info('Pulling latest Docker images...')
-        await tryCatchAsync(
+        const res = await tryCatchAsync(
             'exec(docker-compose)::pull',
             exec({
                 env: makeEnvironment(cfg),
@@ -46,6 +46,10 @@ const run = async function(argv) {
                 pipe: false,
             })
         )
+        if (res.err) {
+            reporter.error('Failed to pull latest Docker images')
+            process.exit(1)
+        }
     }
 
     if (seed || seedFile) {

--- a/packages/cluster/src/commands/up.js
+++ b/packages/cluster/src/commands/up.js
@@ -9,7 +9,7 @@ const {
 } = require('../common')
 
 const defaults = require('../defaults')
-const { seed: doSeed } = require('../db')
+const { restore } = require('../helpers/db')
 
 const run = async function(argv) {
     const { name, seed, seedFile, update, getCache } = argv
@@ -29,8 +29,27 @@ const run = async function(argv) {
         process.exit(1)
     }
 
+    if (update) {
+        reporter.info('Pulling latest Docker images...')
+        await tryCatchAsync(
+            'exec(docker-compose)::pull',
+            exec({
+                env: makeEnvironment(cfg),
+                cmd: 'docker-compose',
+                args: [
+                    '-p',
+                    makeComposeProject(name),
+                    '-f',
+                    path.join(cacheLocation, 'docker-compose.yml'),
+                    'pull',
+                ],
+                pipe: false,
+            })
+        )
+    }
+
     if (seed || seedFile) {
-        await doSeed({
+        await restore({
             name,
             cacheLocation,
             dbVersion: cfg.dbVersion,

--- a/packages/cluster/src/helpers/db/backup.js
+++ b/packages/cluster/src/helpers/db/backup.js
@@ -1,14 +1,12 @@
-const { makeComposeProject, substituteVersion } = require('../../common')
+const { makeComposeProject } = require('../../common')
 const chalk = require('chalk')
 const path = require('path')
-const { reporter, exec, tryCatchAsync } = require('@dhis2/cli-helpers-engine')
+const { reporter, exec } = require('@dhis2/cli-helpers-engine')
 
-const doBackup = async ({
-    cacheLocation,
-    composeProject,
-    destinationFile,
-    fat,
-}) => {
+module.exports = async ({ cacheLocation, name, path: dbPath, fat }) => {
+    const destinationFile = path.resolve(dbPath)
+    const composeProject = makeComposeProject(name)
+
     reporter.info(`Backing up database (this may take some time)...`)
     reporter.debug(`Dumping database to ${chalk.bold(destinationFile)}`)
 
@@ -35,18 +33,4 @@ const doBackup = async ({
             DOCKER_COMPOSE: `docker-compose -p ${composeProject}`,
         },
     })
-}
-
-module.exports = async ({ cacheLocation, name, path: dbPath, fat }) => {
-    const destinationFile = path.resolve(dbPath)
-    const composeProject = makeComposeProject(name)
-    await tryCatchAsync(
-        'db::backup',
-        doBackup({
-            cacheLocation,
-            composeProject,
-            destinationFile,
-            fat,
-        })
-    )
 }

--- a/packages/cluster/src/helpers/db/backup.js
+++ b/packages/cluster/src/helpers/db/backup.js
@@ -1,0 +1,52 @@
+const { makeComposeProject, substituteVersion } = require('../../common')
+const chalk = require('chalk')
+const path = require('path')
+const { reporter, exec, tryCatchAsync } = require('@dhis2/cli-helpers-engine')
+
+const doBackup = async ({
+    cacheLocation,
+    composeProject,
+    destinationFile,
+    fat,
+}) => {
+    reporter.info(`Backing up database (this may take some time)...`)
+    reporter.debug(`Dumping database to ${chalk.bold(destinationFile)}`)
+
+    if (fat) {
+        reporter.info(
+            `Performing fat backup, ${chalk.bold(
+                'including'
+            )} Analytics and Resource tables`
+        )
+    } else {
+        reporter.info(
+            `Performing lean backup, ${chalk.bold(
+                'excluding'
+            )} Analytics and Resource tables`
+        )
+    }
+
+    await exec({
+        cmd: './scripts/backup.sh',
+        cwd: cacheLocation,
+        args: [destinationFile, fat ? 'full' : ''],
+        pipe: false,
+        env: {
+            DOCKER_COMPOSE: `docker-compose -p ${composeProject}`,
+        },
+    })
+}
+
+module.exports = async ({ cacheLocation, name, path: dbPath, fat }) => {
+    const destinationFile = path.resolve(dbPath)
+    const composeProject = makeComposeProject(name)
+    await tryCatchAsync(
+        'db::backup',
+        doBackup({
+            cacheLocation,
+            composeProject,
+            destinationFile,
+            fat,
+        })
+    )
+}

--- a/packages/cluster/src/helpers/db/index.js
+++ b/packages/cluster/src/helpers/db/index.js
@@ -1,0 +1,2 @@
+module.exports.backup = require('./backup')
+module.exports.restore = require('./restore')

--- a/packages/cluster/src/helpers/db/restore.js
+++ b/packages/cluster/src/helpers/db/restore.js
@@ -1,8 +1,8 @@
-const { makeComposeProject, substituteVersion } = require('./common')
+const { makeComposeProject, substituteVersion } = require('../../common')
 const chalk = require('chalk')
 const path = require('path')
 const { reporter, exec, tryCatchAsync } = require('@dhis2/cli-helpers-engine')
-const defaults = require('./defaults')
+const defaults = require('../../defaults')
 
 const downloadDatabase = async ({ cache, path, dbVersion, update, url }) => {
     if (path) {
@@ -37,9 +37,9 @@ const downloadDatabase = async ({ cache, path, dbVersion, update, url }) => {
     }
 }
 
-const seedFromFile = async ({ cacheLocation, dbFile, dbVersion, name }) => {
-    reporter.info(`Seeding database (this may take some time)...`)
-    reporter.debug(`Seeding from database dump ${chalk.bold(dbFile)}`)
+const restoreFromFile = async ({ cacheLocation, dbFile, dbVersion, name }) => {
+    reporter.info(`Restoring database (this may take some time)...`)
+    reporter.debug(`Restoring from database dump ${chalk.bold(dbFile)}`)
 
     await tryCatchAsync(
         'exec(seed.sh)',
@@ -55,7 +55,7 @@ const seedFromFile = async ({ cacheLocation, dbFile, dbVersion, name }) => {
     )
 }
 
-module.exports.seed = async ({
+module.exports = async ({
     cacheLocation,
     dbVersion,
     name,
@@ -72,5 +72,5 @@ module.exports.seed = async ({
               url,
               update,
           })
-    await seedFromFile({ cacheLocation, dbFile, dbVersion, name })
+    await restoreFromFile({ cacheLocation, dbFile, dbVersion, name })
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -15,7 +15,7 @@
         "@dhis2/cli-helpers-engine": "1.3.0",
         "@semantic-release/changelog": "^3.0.4",
         "@semantic-release/commit-analyzer": "^6.2.0",
-        "@semantic-release/git": "^7.0.14",
+        "@semantic-release/git": "^7.0.16",
         "@semantic-release/github": "^5.4.0",
         "@semantic-release/npm": "^5.1.13",
         "@semantic-release/release-notes-generator": "^7.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -225,9 +225,30 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
+"@nodelib/fs.scandir@2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.1.tgz#7fa8fed654939e1a39753d286b48b4836d00e0eb"
+  integrity sha512-NT/skIZjgotDSiXs0WqYhgcuBKhUMgfekCmCGtkUAiLqZdOnrdjmZr9wRl3ll64J9NF79uZ4fk16Dx0yMc/Xbg==
+  dependencies:
+    "@nodelib/fs.stat" "2.0.1"
+    run-parallel "^1.1.9"
+
+"@nodelib/fs.stat@2.0.1", "@nodelib/fs.stat@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.1.tgz#814f71b1167390cfcb6a6b3d9cdeb0951a192c14"
+  integrity sha512-+RqhBlLn6YRBGOIoVYthsG0J9dfpO79eJyN7BYBkZJtfqrBwf2KK+rD/M/yjZR6WBmIhAgOV7S60eCgaSWtbFw==
+
 "@nodelib/fs.stat@^1.1.2":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
+
+"@nodelib/fs.walk@^1.2.1":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.2.tgz#6a6450c5e17012abd81450eb74949a4d970d2807"
+  integrity sha512-J/DR3+W12uCzAJkw7niXDcqcKBg6+5G5Q/ZpThpGNzAUz70eOR6RV4XnnSN01qHZiVl0eavoxJsBypQoKsV2QQ==
+  dependencies:
+    "@nodelib/fs.scandir" "2.1.1"
+    fastq "^1.6.0"
 
 "@octokit/endpoint@^5.1.0":
   version "5.1.2"
@@ -299,17 +320,18 @@
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@semantic-release/error/-/error-2.2.0.tgz#ee9d5a09c9969eade1ec864776aeda5c5cddbbf0"
 
-"@semantic-release/git@^7.0.14":
-  version "7.0.14"
-  resolved "https://registry.yarnpkg.com/@semantic-release/git/-/git-7.0.14.tgz#e5b7afdec2ca30ab9481a5846d047076ab443c93"
+"@semantic-release/git@^7.0.16":
+  version "7.0.16"
+  resolved "https://registry.yarnpkg.com/@semantic-release/git/-/git-7.0.16.tgz#19921d2fdc75d712ae1706330dba8ebec8ced52d"
+  integrity sha512-Bw/npxTVTeFPnQZmuczWRGRdxqJpWOOFZENx38ykyp42InwDFm4n72bfcCwmP/J4WqkPmMR4p+IracWruz/RUw==
   dependencies:
     "@semantic-release/error" "^2.1.0"
     aggregate-error "^3.0.0"
     debug "^4.0.0"
-    dir-glob "^2.0.0"
+    dir-glob "^3.0.0"
     execa "^1.0.0"
     fs-extra "^8.0.0"
-    globby "^9.0.0"
+    globby "^10.0.0"
     lodash "^4.17.4"
     micromatch "^4.0.0"
     p-reduce "^2.0.0"
@@ -548,6 +570,11 @@ array-union@^1.0.2:
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
   dependencies:
     array-uniq "^1.0.1"
+
+array-union@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
+  integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
 array-uniq@^1.0.1:
   version "1.0.3"
@@ -1354,6 +1381,13 @@ dir-glob@^2.0.0, dir-glob@^2.2.2:
   dependencies:
     path-type "^3.0.0"
 
+dir-glob@^3.0.0, dir-glob@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
+  integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
+  dependencies:
+    path-type "^4.0.0"
+
 doctrine@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
@@ -1674,6 +1708,18 @@ fast-glob@^2.2.6:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
+fast-glob@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.0.3.tgz#084221f4225d51553bccd5ff4afc17aafa869412"
+  integrity sha512-scDJbDhN+6S4ELXzzN96Fqm5y1CMRn+Io3C4Go+n/gUKP+LW26Wma6IxLSsX2eAMBUOFmyHKDBrUSuoHsycQ5A==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.1"
+    "@nodelib/fs.walk" "^1.2.1"
+    glob-parent "^5.0.0"
+    is-glob "^4.0.1"
+    merge2 "^1.2.3"
+    micromatch "^4.0.2"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
@@ -1681,6 +1727,13 @@ fast-json-stable-stringify@^2.0.0:
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+
+fastq@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.6.0.tgz#4ec8a38f4ac25f21492673adb7eae9cfef47d1c2"
+  integrity sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==
+  dependencies:
+    reusify "^1.0.0"
 
 figgy-pudding@^3.4.1, figgy-pudding@^3.5.1:
   version "3.5.1"
@@ -1958,6 +2011,13 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
+glob-parent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.0.0.tgz#1dc99f0f39b006d3e92c2c284068382f0c20e954"
+  integrity sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==
+  dependencies:
+    is-glob "^4.0.1"
+
 glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
@@ -1982,6 +2042,20 @@ global-dirs@^0.1.0, global-dirs@^0.1.1:
 globals@^11.1.0, globals@^11.7.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
+
+globby@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-10.0.0.tgz#abfcd0630037ae174a88590132c2f6804e291072"
+  integrity sha512-3LifW9M4joGZasyYPz2A1U74zbC/45fvpXUvO/9KbSa+VV0aGZarWkfdgKyR9sExNP0t0x0ss/UMJpNpcaTspw==
+  dependencies:
+    "@types/glob" "^7.1.1"
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.0.3"
+    glob "^7.1.3"
+    ignore "^5.1.1"
+    merge2 "^1.2.3"
+    slash "^3.0.0"
 
 globby@^9.0.0:
   version "9.2.0"
@@ -2189,6 +2263,11 @@ ignore-walk@^3.0.1:
 ignore@^4.0.3, ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
+
+ignore@^5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.2.tgz#e28e584d43ad7e92f96995019cc43b9e1ac49558"
+  integrity sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==
 
 import-fresh@^2.0.0:
   version "2.0.0"
@@ -2399,7 +2478,7 @@ is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
-is-glob@^4.0.0:
+is-glob@^4.0.0, is-glob@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   dependencies:
@@ -3066,7 +3145,7 @@ micromatch@^3.1.10:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@^4.0.0:
+micromatch@^4.0.0, micromatch@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
   dependencies:
@@ -3822,6 +3901,11 @@ path-type@^3.0.0:
   dependencies:
     pify "^3.0.0"
 
+path-type@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
+  integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -4269,6 +4353,11 @@ retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
 
+reusify@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
 rimraf@2, rimraf@2.6.3, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
@@ -4284,6 +4373,11 @@ run-async@^2.2.0:
 run-node@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/run-node/-/run-node-1.0.0.tgz#46b50b946a2aa2d4947ae1d886e9856fd9cabe5e"
+
+run-parallel@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
+  integrity sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
 
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
This feature PR adds a few handy commands to the `cluster` namespace:

1) It adds `d2 cluster db backup <name> <path>` and `d2 cluster db restore <name> [path]` for easy database lifecycle management outside the cluster volumes.
2) It adds the `d2 cluster compose <name> -- [args...]` command which passes through to the underlying `docker-compose` and allows the user to perform arbitrary `docker-compose` commands without needing to specify the compose project name or the location of the docker-compose.yml file (which is in the d2 cache).  An example usage is `d2 cluster compose dev -- exec db 'sh'` which will execute an interactive shell terminal in the `db` container.
3) It enhances the `d2 cluster up` command by automatically pulling the latest docker images when `--update` is specified

This also deprecates the `d2 cluster seed` command (it's still there to prevent a breaking change, but hidden from the help output) in favor of `d2 cluster db restore`