### PR TITLE
feat: include the docs folder when pushing back a release commit

### DIFF
--- a/packages/utils/src/cmds/release.js
+++ b/packages/utils/src/cmds/release.js
@@ -64,6 +64,7 @@ const handler = async ({ publish }) => {
         {
             assets: [
                 'CHANGELOG.md',
+                'docs',
                 packages.map(pkgJsonPath =>
                     path.relative(process.cwd(), pkgJsonPath)
                 ),
@@ -116,9 +117,7 @@ const handler = async ({ publish }) => {
             const { lastRelease, commits, nextRelease, releases } = result
 
             reporter.info(
-                `Published ${nextRelease.type} release version ${
-                    nextRelease.version
-                } containing ${commits.length} commits.`
+                `Published ${nextRelease.type} release version ${nextRelease.version} containing ${commits.length} commits.`
             )
 
             if (lastRelease.version) {
@@ -127,9 +126,7 @@ const handler = async ({ publish }) => {
 
             for (const release of releases) {
                 reporter.info(
-                    `The release was published with plugin "${
-                        release.pluginName
-                    }".`
+                    `The release was published with plugin "${release.pluginName}".`
                 )
             }
         } else {


### PR DESCRIPTION
For libraries such as `ui-core`, `d2`, `prop-types`, it makes sense to generate a `docs/` folder when the release commit is built on CI, which is then pushed back to the default branch when a release commit is cut.

This would allow us to drop the additional step of pushing libraries to the d2-ci organisation on Github, and having docs together with the release.