### PR TITLE
feat: add `cluster list` command

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,7 +12,7 @@
     "license": "BSD-3-Clause",
     "private": false,
     "dependencies": {
-        "@dhis2/cli-helpers-engine": "1.3.0"
+        "@dhis2/cli-helpers-engine": "1.4.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/cluster/package.json
+++ b/packages/cluster/package.json
@@ -7,7 +7,7 @@
     "author": "Austin McGee <austin@dhis2.org>",
     "license": "BSD-3-Clause",
     "dependencies": {
-        "@dhis2/cli-helpers-engine": "1.3.0",
+        "@dhis2/cli-helpers-engine": "1.4.0",
         "chalk": "^2.4.2"
     },
     "bin": {

--- a/packages/cluster/src/commands/list.js
+++ b/packages/cluster/src/commands/list.js
@@ -1,0 +1,68 @@
+const chalk = require('chalk')
+const path = require('path')
+const { reporter, exec, tryCatchAsync } = require('@dhis2/cli-helpers-engine')
+const { makeComposeProject, listClusters } = require('../common')
+const Table = require('cli-table3')
+
+const run = async function(argv) {
+    const clusters = await listClusters(argv)
+
+    const table = new Table({
+        head: [
+            'Name',
+            'Port',
+            'Channel',
+            'DHIS2 Version',
+            'DB Version',
+            'Status',
+        ],
+    })
+
+    await Promise.all(
+        clusters.map(async cluster => {
+            let status = await exec({
+                cmd: 'docker',
+                args: [
+                    'ps',
+                    '--filter',
+                    `name=${makeComposeProject(cluster.name)}_core`,
+                    '--format',
+                    '{{.Status}}',
+                ],
+                pipe: false,
+                captureOut: true,
+            })
+
+            if (status.length === 0) {
+                status = chalk.grey('Down')
+            } else if (/\(Paused\)/.test(status)) {
+                status = chalk.cyan(status)
+            } else if (/$Up \d+/.test(status)) {
+                status = chalk.green(status)
+            } else {
+                status = chalk.yellow(status)
+            }
+            cluster.status = status
+        })
+    )
+
+    clusters.forEach(cluster =>
+        table.push([
+            chalk.blue(cluster.name),
+            cluster.port,
+            cluster.channel,
+            cluster.dhis2Version,
+            cluster.dbVersion,
+            cluster.status.trim(),
+        ])
+    )
+
+    reporter.print(table)
+}
+
+module.exports = {
+    command: 'list',
+    desc: 'List all active cluster configurations',
+    aliases: 'ls',
+    handler: run,
+}

--- a/packages/cluster/src/common.js
+++ b/packages/cluster/src/common.js
@@ -164,7 +164,15 @@ module.exports.makeEnvironment = cfg => {
 
 module.exports.makeComposeProject = name => `d2-cluster-${name}`
 
-module.exports.getLocalClusters = async () => {}
+module.exports.listClusters = async argv => {
+    const cache = argv.getCache()
+
+    const stat = await cache.stat(clusterDir)
+    const promises = Object.keys(stat.children)
+        .filter(name => cache.exists(path.join(clusterDir, name)))
+        .map(name => resolveConfiguration({ name, getCache: argv.getCache }))
+    return await Promise.all(promises)
+}
 
 module.exports.makeDockerImage = makeDockerImage
 module.exports.resolveConfiguration = resolveConfiguration

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -8,7 +8,7 @@
     "license": "BSD-3-Clause",
     "dependencies": {
         "@dhis2/cli-create": "2.0.0",
-        "@dhis2/cli-helpers-engine": "1.3.0"
+        "@dhis2/cli-helpers-engine": "1.4.0"
     },
     "bin": "./bin/d2-create-app",
     "publishConfig": {

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -9,7 +9,7 @@
     "license": "BSD-3-Clause",
     "private": false,
     "dependencies": {
-        "@dhis2/cli-helpers-engine": "1.3.0",
+        "@dhis2/cli-helpers-engine": "1.4.0",
         "chalk": "^2.4.2",
         "fs-extra": "^8.1.0",
         "handlebars": "^4.1.0",

--- a/packages/create/templates/cli/package.json
+++ b/packages/create/templates/cli/package.json
@@ -9,7 +9,7 @@
     "license": "BSD-3-Clause",
     "private": false,
     "dependencies": {
-        "@dhis2/cli-helpers-engine": "1.3.0"
+        "@dhis2/cli-helpers-engine": "1.4.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -15,7 +15,7 @@
         "@dhis2/cli-app": "2.0.0",
         "@dhis2/cli-cluster": "2.0.0",
         "@dhis2/cli-create": "2.0.0",
-        "@dhis2/cli-helpers-engine": "1.3.0",
+        "@dhis2/cli-helpers-engine": "1.4.0",
         "@dhis2/cli-style": "4.1.1",
         "@dhis2/cli-utils": "2.0.0",
         "cli-table3": "^0.5.1",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -12,7 +12,7 @@
     "license": "BSD-3-Clause",
     "private": false,
     "dependencies": {
-        "@dhis2/cli-helpers-engine": "1.3.0",
+        "@dhis2/cli-helpers-engine": "1.4.0",
         "@semantic-release/changelog": "^3.0.4",
         "@semantic-release/commit-analyzer": "^6.3.0",
         "@semantic-release/git": "^7.0.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -141,6 +141,18 @@
     update-notifier "^3.0.0"
     yargs "^13.1.0"
 
+"@dhis2/cli-helpers-engine@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/cli-helpers-engine/-/cli-helpers-engine-1.4.0.tgz#6371bce3017a5bc0c2b8ea84b77f253d75b8771e"
+  integrity sha512-2WLWJ5DcIiECmUlX2ChU2Wbqe/iJ42nDPQGjQXK1YzryNdnXyftUjJRwrLYWwaKGmWzfnPvpu8tvp+Yjysl78A==
+  dependencies:
+    chalk "^2.4.2"
+    fs-extra "^8.0.1"
+    request "^2.88.0"
+    tar "^4.4.8"
+    update-notifier "^3.0.0"
+    yargs "^13.1.0"
+
 "@dhis2/cli-style@4.1.1":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@dhis2/cli-style/-/cli-style-4.1.1.tgz#0d7da6684bb1b506a741c6ce020b5030c3132322"
@@ -3505,7 +3517,6 @@ npm@^6.10.3:
     cmd-shim "^3.0.3"
     columnify "~1.5.4"
     config-chain "^1.1.12"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -3520,7 +3531,6 @@ npm@^6.10.3:
     has-unicode "~2.0.1"
     hosted-git-info "^2.8.2"
     iferr "^1.0.2"
-    imurmurhash "*"
     infer-owner "^1.0.4"
     inflight "~1.0.6"
     inherits "^2.0.4"
@@ -3539,14 +3549,8 @@ npm@^6.10.3:
     libnpx "^10.2.0"
     lock-verify "^2.1.0"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"


### PR DESCRIPTION
This adds the command `d2 cluster list` which displays a list of the configured clusters and their current status, i.e.

<img width="499" alt="Screenshot 2019-08-24 13 43 31" src="https://user-images.githubusercontent.com/947888/63636831-368a0900-c675-11e9-8372-021ad781aee5.png">

It also upgrades the dependency on `@dhis2/cli-helpers-engine` which fixes a bug in the Cache implementation and adds support for capturing the output of `exec` commands.