### PR TITLE
fix: improve cluster list formatting

### DIFF
--- a/packages/cluster/src/commands/list.js
+++ b/packages/cluster/src/commands/list.js
@@ -26,7 +26,7 @@ const formatStatus = status => {
         return chalk.grey('Down')
     } else if (/\(Paused\)$/.test(status)) {
         return chalk.cyan(status)
-    } else if (/^Up \d+/.test(status)) {
+    } else if (/^Up/.test(status)) {
         return chalk.green(status)
     } else {
         return chalk.yellow(status)

--- a/packages/cluster/src/commands/list.js
+++ b/packages/cluster/src/commands/list.js
@@ -10,6 +10,7 @@ const getStatus = async cluster =>
         cmd: 'docker',
         args: [
             'ps',
+            '-a', // Include stopped containers
             '--filter',
             `name=${makeComposeProject(cluster.name)}_core`,
             '--format',
@@ -28,6 +29,8 @@ const formatStatus = status => {
         return chalk.cyan(status)
     } else if (/^Up/.test(status)) {
         return chalk.green(status)
+    } else if (/^Exited/.test(status)) {
+        return chalk.red(status)
     } else {
         return chalk.yellow(status)
     }


### PR DESCRIPTION
Fixes a minor bug where `Up about a minute` didn't match the `Up \d+` regex.  Also passes `-a` to `docker ps` so that we can also see stopped containers, and adds a status check for `Exited`