### PR TITLE
fix: don't swallow release command errors

### DIFF
--- a/packages/utils/src/cmds/release.js
+++ b/packages/utils/src/cmds/release.js
@@ -133,6 +133,7 @@ const handler = async ({ publish }) => {
         }
     } catch (err) {
         reporter.error(`The automated release failed with ${err}`)
+        process.exit(1)
     }
 }
 


### PR DESCRIPTION
This can cause [release failures to silently succeed](https://travis-ci.com/dhis2/app-platform/builds/126588761#L472), which is bad news in CI deployment 

I'm also worried that the git portion of semantic-release [succeeded](https://github.com/dhis2/app-platform/commit/bef5557c48e6fc429c41a44ff288fb7afa45440f) in pushing the version commit, even though the preceding npm publish step failed!  That is not covered in this fix.