### PR TITLE
chore: list doesn't output ugly error if cache folder doesn't exist

### DIFF
--- a/packages/cluster/src/common.js
+++ b/packages/cluster/src/common.js
@@ -171,6 +171,9 @@ module.exports.makeComposeProject = name => `d2-cluster-${normalizeName(name)}`
 module.exports.listClusters = async argv => {
     const cache = argv.getCache()
 
+    const exists = await cache.exists(clusterDir)
+    if (!exists) return []
+
     const stat = await cache.stat(clusterDir)
     const promises = Object.keys(stat.children)
         .filter(name => cache.exists(path.join(clusterDir, name)))


### PR DESCRIPTION
See title. Not much to say.
Had one student who thought something had gone wrong when they saw the error.