### PR TITLE
fix(release): avoid picking a prop from undefined

### DIFF
--- a/packages/utils/src/cmds/release.js
+++ b/packages/utils/src/cmds/release.js
@@ -117,11 +117,13 @@ const handler = async ({ publish }) => {
         if (result) {
             const { lastRelease, commits, nextRelease, releases } = result
 
-            reporter.info(
-                `Published ${nextRelease.type} release version ${nextRelease.version} containing ${commits.length} commits.`
-            )
+            if (nextRelease) {
+                reporter.info(
+                    `Published ${nextRelease.type} release version ${nextRelease.version} containing ${commits.length} commits.`
+                )
+            }
 
-            if (lastRelease.version) {
+            if (lastRelease) {
                 reporter.info(`The last release was "${lastRelease.version}".`)
             }
 


### PR DESCRIPTION
Adds check if nextRelease and lastRelease are truthy before picking
props from them.

In some situations when running semantic-release we get a result back
that has `nextRelease` as undefined. We naively read from that object
and wind up with a "cannot read property from undefined" error that
makes the process exit with code 1, marking it as failed in CI.

Technically this may be a bug in semantic-release, as their docs state
that the result obj should be false or complete[1].

And example for how this looks in CI is attached[2].

[1] https://github.com/semantic-release/semantic-release/blob/master/docs/developer-guide/js-api.md#result
[2] https://github.com/dhis2/app-hub/runs/554982530#step:9:109