### PR TITLE
fix: don't set DHIS2_CORE_CONFIG to undefined, it needs to be unset

### DIFF
--- a/packages/cluster/src/common.js
+++ b/packages/cluster/src/common.js
@@ -155,7 +155,9 @@ module.exports.makeEnvironment = cfg => {
         DHIS2_CORE_VERSION: cfg.dhis2Version,
         DHIS2_CORE_DB_VERSION: cfg.dbVersion,
         DHIS2_CORE_PORT: cfg.port,
-        DHIS2_CORE_CONFIG: cfg.dhis2Config,
+    }
+    if (cfg.dhis2Config) {
+        env.DHIS2_CORE_CONFIG = cfg.dhis2Config
     }
 
     reporter.debug('Runtime environment\n', env)

--- a/packages/cluster/tests/setup-environment.js
+++ b/packages/cluster/tests/setup-environment.js
@@ -27,7 +27,6 @@ test('build runtime environment based on defaults', async function(t) {
         DHIS2_CORE_VERSION: 'dev',
         DHIS2_CORE_DB_VERSION: 'dev',
         DHIS2_CORE_PORT: defaults.port,
-        DHIS2_CORE_CONFIG: undefined,
     }
 
     t.deepEqual(actual, expected, 'default environment')
@@ -57,7 +56,6 @@ test('build runtime environment based on args', async function(t) {
         DHIS2_CORE_VERSION: '2.33',
         DHIS2_CORE_DB_VERSION: '2.32',
         DHIS2_CORE_PORT: 8233,
-        DHIS2_CORE_CONFIG: undefined,
     }
 
     t.deepEqual(actual, expected, 'args environment')
@@ -90,7 +88,6 @@ test('build runtime environment based on mixed args and config', async function(
         DHIS2_CORE_VERSION: 'master',
         DHIS2_CORE_DB_VERSION: 'dev',
         DHIS2_CORE_PORT: 8233,
-        DHIS2_CORE_CONFIG: undefined,
     }
 
     t.deepEqual(actual, expected, 'args and config environment')
@@ -124,7 +121,6 @@ test('build runtime environment based on mixed args, cache, config and defaults'
         DHIS2_CORE_VERSION: 'dev',
         DHIS2_CORE_DB_VERSION: 'dev',
         DHIS2_CORE_PORT: 8233,
-        DHIS2_CORE_CONFIG: undefined,
     }
 
     t.deepEqual(actual, expected, 'merged environment')
@@ -165,7 +161,6 @@ test('build runtime environment based on mixed args, cache, config, custom per-c
         DHIS2_CORE_VERSION: 'apa',
         DHIS2_CORE_DB_VERSION: 'dev',
         DHIS2_CORE_PORT: 9999,
-        DHIS2_CORE_CONFIG: undefined,
     }
 
     t.deepEqual(actual, expected, 'merged environment')


### PR DESCRIPTION
This caused the below error on a fresh cluster with default config:

```sh
> d2 cluster up master --verbose
[DEBUG] Resolved configuration
 { dhis2Version: 'master',
  dbVersion: 'dev',
  channel: 'dev',
  image: 'dhis2/core{channel}:{version}',
  port: 8080,
  customContext: false,
  update: false,
  seed: false,
  dockerComposeDirectory: 'cluster',
  dockerComposeRepository: 'https://github.com/dhis2/docker-compose/archive/master.tar.gz',
  demoDatabaseURL: 'https://github.com/dhis2/dhis2-demo-db/blob/master/sierra-leone/{version}/dhis2-db-sierra-leone.sql.gz?raw=true',
  _: [ 'cluster', 'up' ],
  verbose: true,
  cache: '/Users/awm/.cache/d2',
  '$0': '/usr/local/bin/d2',
  name: 'master',
  getCache: [Function],
  contextPath: '',
  dockerImage: 'dhis2/core-dev:master' }
[DEBUG] Skipping docker compose repo initialization, found cached dir 
Spinning up cluster master 
[DEBUG] Runtime environment
 { DHIS2_CORE_NAME: 'master',
  DHIS2_CORE_IMAGE: 'dhis2/core-dev:master',
  DHIS2_CORE_CONTEXT_PATH: '',
  DHIS2_CORE_VERSION: 'master',
  DHIS2_CORE_DB_VERSION: 'dev',
  DHIS2_CORE_PORT: 8080,
  DHIS2_CORE_CONFIG: undefined }
[DEBUG] > docker-compose -p d2-cluster-master -f /Users/awm/.cache/d2/cache/clusters/master/docker-compose/cluster/docker-compose.yml up -d 
[DEBUG] env: {"DHIS2_CORE_NAME":"master","DHIS2_CORE_IMAGE":"dhis2/core-dev:master","DHIS2_CORE_CONTEXT_PATH":"","DHIS2_CORE_VERSION":"master","DHIS2_CORE_DB_VERSION":"dev","DHIS2_CORE_PORT":8080} 
Named volume "undefined:/DHIS2_home/dhis.conf:rw" is used in service "core" but no declaration was found in the volumes section.
 
[DEBUG ERROR] docker-compose exited with non-zero exit code (1). 
[DEBUG] tryCatchAsync(exec(docker-compose)) error: undefined 
[ERROR] Failed to spin up cluster docker-compose cluster 
```