### PR TITLE
fix: add cli-table3 as d2-cluster dependency

### DIFF
--- a/packages/cluster/package.json
+++ b/packages/cluster/package.json
@@ -7,7 +7,8 @@
     "author": "Austin McGee <austin@dhis2.org>",
     "license": "BSD-3-Clause",
     "dependencies": {
-        "@dhis2/cli-helpers-engine": "^2.0.0"
+        "@dhis2/cli-helpers-engine": "^2.0.0",
+        "cli-table3": "^0.6.0"
     },
     "bin": {
         "d2-cluster": "./bin/d2-cluster"

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -18,7 +18,7 @@
         "@dhis2/cli-helpers-engine": "^2.0.0",
         "@dhis2/cli-style": "^7.0.0",
         "@dhis2/cli-utils": "3.0.2",
-        "cli-table3": "^0.5.1",
+        "cli-table3": "^0.6.0",
         "envinfo": "^7.5.0",
         "inquirer": "^7.1.0"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5236,6 +5236,16 @@ cli-table3@0.5.1, cli-table3@^0.5.0, cli-table3@^0.5.1:
   optionalDependencies:
     colors "^1.1.2"
 
+cli-table3@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.0.tgz#b7b1bc65ca8e7b5cef9124e13dc2b21e2ce4faee"
+  integrity sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==
+  dependencies:
+    object-assign "^4.1.0"
+    string-width "^4.2.0"
+  optionalDependencies:
+    colors "^1.1.2"
+
 cli-table@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cli-table/-/cli-table-0.3.1.tgz#f53b05266a8b1a0b934b3d0821e6e2dc5914ae23"


### PR DESCRIPTION
Closes #315 

The `cluster` package is [using `cli-table3`](https://github.com/dhis2/cli/blob/d404134ac71c138afd9a89b418978be5e55d3e77/packages/cluster/src/commands/list.js#L3), but that dependency was only declared for the main `d2` package (`@dhis2/cli`).  When installed and run independently (`npx @dhis2/cli-cluster --help`, not recommended but exhibiting this issue) the `cluster` command can't resolve the `cli-table3` dependency because it is only installed with the full CLI.  `yarn global add @dhis2/cli && d2 cluster --help` worked, but we should be explicit in our dependency declarations.

The following error is caused by this missing dependency:

```bash
➜ npx @dhis2/cli-cluster --help
npx: installed 190 in 13.261s
Cannot find module 'cli-table3'
Require stack:
- /Users/awm/.npm/_npx/4458/lib/node_modules/@dhis2/cli-cluster/src/commands/list.js
- /Users/awm/.npm/_npx/4458/lib/node_modules/@dhis2/cli-cluster/node_modules/yargs/index.js
- /Users/awm/.npm/_npx/4458/lib/node_modules/@dhis2/cli-cluster/node_modules/@dhis2/cli-helpers-engine/lib/cache/middleware.js
- /Users/awm/.npm/_npx/4458/lib/node_modules/@dhis2/cli-cluster/node_modules/@dhis2/cli-helpers-engine/lib/cache/index.js
- /Users/awm/.npm/_npx/4458/lib/node_modules/@dhis2/cli-cluster/node_modules/@dhis2/cli-helpers-engine/index.js
- /Users/awm/.npm/_npx/4458/lib/node_modules/@dhis2/cli-cluster/bin/d2-cluster
```

This also upgrades `cli-table3` to version `0.6.0` which deprecates node version < 10 (we bumped our required node version in #302)