### PR TITLE
fix: use new location for sample database downloads

### DIFF
--- a/packages/cluster/src/defaults.js
+++ b/packages/cluster/src/defaults.js
@@ -11,5 +11,5 @@ module.exports = {
     dockerComposeRepository:
         'https://github.com/dhis2/docker-compose/archive/master.tar.gz',
     demoDatabaseURL:
-        'https://github.com/dhis2/dhis2-demo-db/blob/master/sierra-leone/{version}/dhis2-db-sierra-leone.sql.gz?raw=true',
+        'https://databases.dhis2.org/sierra-leone/{version}/dhis2-db-sierra-leone.sql.gz'
 }

--- a/packages/cluster/src/defaults.js
+++ b/packages/cluster/src/defaults.js
@@ -11,5 +11,5 @@ module.exports = {
     dockerComposeRepository:
         'https://github.com/dhis2/docker-compose/archive/master.tar.gz',
     demoDatabaseURL:
-        'https://databases.dhis2.org/sierra-leone/{version}/dhis2-db-sierra-leone.sql.gz'
+        'https://databases.dhis2.org/sierra-leone/{version}/dhis2-db-sierra-leone.sql.gz',
 }


### PR DESCRIPTION
Closes #317 - DHIS2 Sierra Leone demo databases are no longer hosted primarily on GitHub, so update the default url for seed database download to point to the new location.