### PR TITLE
fix(release): always update package.json version

### DIFF
--- a/packages/utils/src/cmds/release.js
+++ b/packages/utils/src/cmds/release.js
@@ -27,7 +27,15 @@ function publisher(target = '', packages) {
         }
 
         default: {
-            return [undefined]
+            return packages.filter(packageIsPublishable).map(pkgJsonPath => {
+                return [
+                    '@semantic-release/npm',
+                    {
+                        pkgRoot: path.dirname(pkgJsonPath),
+                        npmPublish: false,
+                    },
+                ]
+            })
         }
     }
 }


### PR DESCRIPTION
When not releasing to NPM in a standard repo (as opposed to a monorepo),
no logic to update the package.json version field was triggered.

This change runs the semantic-release/npm[1] plugin with "npmPublish"
disabled. This updates the package.json version field without publishing
to NPM.

In normal operation we do want to trigger the release, so if the
publisher is set to 'npm' it works according to the default.

[1] https://github.com/semantic-release/npm#options
