### PR TITLE
feat(cli): prefer project-local tools

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -16,7 +16,7 @@
     "private": false,
     "dependencies": {
         "@dhis2/cli-app-scripts": "^8.3.0",
-        "@dhis2/cli-helpers-engine": "^3.0.0"
+        "@dhis2/cli-helpers-engine": "^3.1.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/app/src/index.js
+++ b/packages/app/src/index.js
@@ -1,9 +1,13 @@
-const { namespace } = require('@dhis2/cli-helpers-engine')
+const { namespace, loadModule } = require('@dhis2/cli-helpers-engine')
 
 module.exports = namespace('app', {
     description: 'Front-end application and library commands',
     builder: yargs => {
-        yargs.command(require('@dhis2/cli-app-scripts'))
+        const loader = loadModule({
+            parentModule: __filename,
+        })
+
+        yargs.command(loader('@dhis2/cli-app-scripts'))
         yargs.commandDir('commands')
     },
 })

--- a/packages/app/src/index.js
+++ b/packages/app/src/index.js
@@ -1,9 +1,9 @@
-const { namespace, loadModule } = require('@dhis2/cli-helpers-engine')
+const { namespace, createModuleLoader } = require('@dhis2/cli-helpers-engine')
 
 module.exports = namespace('app', {
     description: 'Front-end application and library commands',
     builder: yargs => {
-        const loader = loadModule({
+        const loader = createModuleLoader({
             parentModule: __filename,
         })
 

--- a/packages/cluster/package.json
+++ b/packages/cluster/package.json
@@ -7,7 +7,7 @@
     "author": "Austin McGee <austin@dhis2.org>",
     "license": "BSD-3-Clause",
     "dependencies": {
-        "@dhis2/cli-helpers-engine": "^3.0.0",
+        "@dhis2/cli-helpers-engine": "^3.1.0",
         "cli-table3": "^0.6.0"
     },
     "bin": {

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -8,7 +8,7 @@
     "license": "BSD-3-Clause",
     "dependencies": {
         "@dhis2/cli-create": "4.1.0",
-        "@dhis2/cli-helpers-engine": "^3.0.0"
+        "@dhis2/cli-helpers-engine": "^3.1.0"
     },
     "bin": "./bin/d2-create-app",
     "engines": {

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -12,7 +12,7 @@
     "license": "BSD-3-Clause",
     "private": false,
     "dependencies": {
-        "@dhis2/cli-helpers-engine": "^3.0.0",
+        "@dhis2/cli-helpers-engine": "^3.1.0",
         "@dhis2/cli-helpers-template": "^3.0.0",
         "fs-extra": "^9.0.0",
         "handlebars": "^4.7.3",

--- a/packages/create/templates/cli/package.json
+++ b/packages/create/templates/cli/package.json
@@ -9,7 +9,7 @@
     "license": "BSD-3-Clause",
     "private": false,
     "dependencies": {
-        "@dhis2/cli-helpers-engine": "^1.5.0"
+        "@dhis2/cli-helpers-engine": "^3.1.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -15,7 +15,7 @@
         "@dhis2/cli-app": "4.1.0",
         "@dhis2/cli-cluster": "4.1.0",
         "@dhis2/cli-create": "4.1.0",
-        "@dhis2/cli-helpers-engine": "^3.0.0",
+        "@dhis2/cli-helpers-engine": "^3.1.0",
         "@dhis2/cli-style": "^9.0.1",
         "@dhis2/cli-utils": "4.1.0",
         "cli-table3": "^0.6.0",

--- a/packages/main/src/index.js
+++ b/packages/main/src/index.js
@@ -1,35 +1,17 @@
-const path = require('path')
-const {
-    namespace,
-    findProjectRoot,
-    reporter,
-} = require('@dhis2/cli-helpers-engine')
-
-function load(tool) {
-    const root = findProjectRoot()
-    const paths = root ? [path.resolve(root, 'node_modules')] : []
-
-    try {
-        const resolved = require.resolve(tool, {
-            paths,
-        })
-
-        reporter.debug(`Loading tool from: ${resolved}`)
-        return require(resolved)
-    } catch (err) {
-        reporter.debug(`Loading tool from: ${tool}`)
-        return require(tool)
-    }
-}
+const { namespace, loadModule } = require('@dhis2/cli-helpers-engine')
 
 const command = namespace('d2', {
     desc: 'DHIS2 CLI',
     builder: yargs => {
-        yargs.command(load('@dhis2/cli-app'))
-        yargs.command(load('@dhis2/cli-cluster'))
-        yargs.command(load('@dhis2/cli-create'))
-        yargs.command(load('@dhis2/cli-style').command)
-        yargs.command(load('@dhis2/cli-utils'))
+        const loader = loadModule({
+            parentModule: __filename,
+        })
+
+        yargs.command(loader('@dhis2/cli-app'))
+        yargs.command(loader('@dhis2/cli-cluster'))
+        yargs.command(loader('@dhis2/cli-create'))
+        yargs.command(loader('@dhis2/cli-style').command)
+        yargs.command(loader('@dhis2/cli-utils'))
         yargs.commandDir('commands')
     },
 })

--- a/packages/main/src/index.js
+++ b/packages/main/src/index.js
@@ -1,9 +1,9 @@
-const { namespace, loadModule } = require('@dhis2/cli-helpers-engine')
+const { namespace, createModuleLoader } = require('@dhis2/cli-helpers-engine')
 
 const command = namespace('d2', {
     desc: 'DHIS2 CLI',
     builder: yargs => {
-        const loader = loadModule({
+        const loader = createModuleLoader({
             parentModule: __filename,
         })
 

--- a/packages/main/src/index.js
+++ b/packages/main/src/index.js
@@ -1,13 +1,35 @@
-const { namespace } = require('@dhis2/cli-helpers-engine')
+const path = require('path')
+const {
+    namespace,
+    findProjectRoot,
+    reporter,
+} = require('@dhis2/cli-helpers-engine')
+
+function load(tool) {
+    const root = findProjectRoot()
+    const paths = root ? [path.resolve(root, 'node_modules')] : []
+
+    try {
+        const resolved = require.resolve(tool, {
+            paths,
+        })
+
+        reporter.debug(`Loading tool from: ${resolved}`)
+        return require(resolved)
+    } catch (err) {
+        reporter.debug(`Loading tool from: ${tool}`)
+        return require(tool)
+    }
+}
 
 const command = namespace('d2', {
     desc: 'DHIS2 CLI',
     builder: yargs => {
-        yargs.command(require('@dhis2/cli-app'))
-        yargs.command(require('@dhis2/cli-cluster'))
-        yargs.command(require('@dhis2/cli-create'))
-        yargs.command(require('@dhis2/cli-style').command)
-        yargs.command(require('@dhis2/cli-utils'))
+        yargs.command(load('@dhis2/cli-app'))
+        yargs.command(load('@dhis2/cli-cluster'))
+        yargs.command(load('@dhis2/cli-create'))
+        yargs.command(load('@dhis2/cli-style').command)
+        yargs.command(load('@dhis2/cli-utils'))
         yargs.commandDir('commands')
     },
 })

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -15,7 +15,7 @@
     "license": "BSD-3-Clause",
     "private": false,
     "dependencies": {
-        "@dhis2/cli-helpers-engine": "^3.0.0",
+        "@dhis2/cli-helpers-engine": "^3.1.0",
         "@dhis2/cli-utils-codemods": "^3.0.0",
         "@dhis2/cli-utils-cypress": "^9.0.1",
         "@dhis2/cli-utils-docsite": "^3.1.2",

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -1,9 +1,9 @@
-const { namespace, loadModule } = require('@dhis2/cli-helpers-engine')
+const { namespace, createModuleLoader } = require('@dhis2/cli-helpers-engine')
 
 const command = namespace('utils', {
     desc: 'Utils for miscellaneous operations',
     builder: yargs => {
-        const loader = loadModule({
+        const loader = createModuleLoader({
             parentModule: __filename,
         })
 

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -1,11 +1,15 @@
-const { namespace } = require('@dhis2/cli-helpers-engine')
+const { namespace, loadModule } = require('@dhis2/cli-helpers-engine')
 
 const command = namespace('utils', {
     desc: 'Utils for miscellaneous operations',
     builder: yargs => {
-        yargs.command(require('@dhis2/cli-utils-cypress'))
-        yargs.command(require('@dhis2/cli-utils-codemods'))
-        yargs.command(require('@dhis2/cli-utils-docsite'))
+        const loader = loadModule({
+            parentModule: __filename,
+        })
+
+        yargs.command(loader('@dhis2/cli-utils-cypress'))
+        yargs.command(loader('@dhis2/cli-utils-codemods'))
+        yargs.command(loader('@dhis2/cli-utils-docsite'))
         yargs.commandDir('cmds')
     },
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2465,6 +2465,21 @@
     update-notifier "^3.0.0"
     yargs "^13.1.0"
 
+"@dhis2/cli-helpers-engine@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/cli-helpers-engine/-/cli-helpers-engine-3.1.0.tgz#9584e7ecb35dd2f1d2650164d8637fed71d225b9"
+  integrity sha512-nKpuGjP+eEuovrtskDco5bfCew7jTcJZhDmAyfK7sZVhI7SNEPXH8vIHFPXWduROOFoAmxvLiyW6WiVfu9X6tA==
+  dependencies:
+    chalk "^3.0.0"
+    cross-spawn "^7.0.3"
+    find-up "^5.0.0"
+    fs-extra "^8.0.1"
+    inquirer "^7.3.3"
+    request "^2.88.0"
+    tar "^4.4.8"
+    update-notifier "^3.0.0"
+    yargs "^13.1.0"
+
 "@dhis2/cli-helpers-template@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@dhis2/cli-helpers-template/-/cli-helpers-template-3.0.0.tgz#1cfb625a6e1a6a824386bd0cfd3ba646783920c3"
@@ -17638,8 +17653,10 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
+    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
+    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
Increases the utility of the global d2 tool for developers by preferring
the version of the CLI tool that is installed over the globally bundled
one.

Before this change these two commands run in the same project can yield
different results:

    d2 style check          # global
    yarn d2-style check     # local

After the change, they will both use the local version:

    d2 style check          # local
    yarn d2-style check     # local

Jira-ticket-key: CLI-68
Jira-ticket-URL: https://jira.dhis2.org/browse/CLI-68

Depends on:
- https://github.com/dhis2/cli-helpers-engine/pull/143