### PR TITLE
fix: bump cli-helpers-engine for all packages

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -16,7 +16,7 @@
     "private": false,
     "dependencies": {
         "@dhis2/cli-app-scripts": "^8.3.0",
-        "@dhis2/cli-helpers-engine": "^3.1.0"
+        "@dhis2/cli-helpers-engine": "^3.2.1"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/cluster/package.json
+++ b/packages/cluster/package.json
@@ -7,7 +7,7 @@
     "author": "Austin McGee <austin@dhis2.org>",
     "license": "BSD-3-Clause",
     "dependencies": {
-        "@dhis2/cli-helpers-engine": "^3.1.0",
+        "@dhis2/cli-helpers-engine": "^3.2.1",
         "cli-table3": "^0.6.0"
     },
     "bin": {

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -8,7 +8,7 @@
     "license": "BSD-3-Clause",
     "dependencies": {
         "@dhis2/cli-create": "4.2.1",
-        "@dhis2/cli-helpers-engine": "^3.1.0"
+        "@dhis2/cli-helpers-engine": "^3.2.1"
     },
     "bin": "./bin/d2-create-app",
     "engines": {

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -12,7 +12,7 @@
     "license": "BSD-3-Clause",
     "private": false,
     "dependencies": {
-        "@dhis2/cli-helpers-engine": "^3.1.0",
+        "@dhis2/cli-helpers-engine": "^3.2.1",
         "@dhis2/cli-helpers-template": "^3.0.0",
         "fs-extra": "^9.0.0",
         "handlebars": "^4.7.3",

--- a/packages/create/templates/cli/package.json
+++ b/packages/create/templates/cli/package.json
@@ -9,7 +9,7 @@
     "license": "BSD-3-Clause",
     "private": false,
     "dependencies": {
-        "@dhis2/cli-helpers-engine": "^3.1.0"
+        "@dhis2/cli-helpers-engine": "^3.2.1"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -15,7 +15,7 @@
     "license": "BSD-3-Clause",
     "private": false,
     "dependencies": {
-        "@dhis2/cli-helpers-engine": "^3.1.0",
+        "@dhis2/cli-helpers-engine": "^3.2.1",
         "@dhis2/cli-utils-codemods": "^3.0.0",
         "@dhis2/cli-utils-cypress": "^9.0.1",
         "@dhis2/cli-utils-docsite": "^3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2045,7 +2045,7 @@
     update-notifier "^3.0.0"
     yargs "^13.1.0"
 
-"@dhis2/cli-helpers-engine@^3.0.0", "@dhis2/cli-helpers-engine@^3.1.0", "@dhis2/cli-helpers-engine@^3.2.1":
+"@dhis2/cli-helpers-engine@^3.0.0", "@dhis2/cli-helpers-engine@^3.2.1":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@dhis2/cli-helpers-engine/-/cli-helpers-engine-3.2.1.tgz#80d3f5b50ae223e5ed3f91550c81c30c3d7741a7"
   integrity sha512-8VRM7KMuiGudogiKmpD7dfjp4Y9aSmmh1dGnTq57kdIQLw/o3CqGqz61BSw41SN/t9hxZvYAy8fBaujPAgL1sQ==


### PR DESCRIPTION
Bump `@dhis2/cli-helpers-engine` for all packages under the `cli` workspace. Prevents issues where a global install of `@dhis2/cli` is upgraded to benefit from the project root handling fix while subpackages such as `@dhis2/cli-app` do not.