### PR TITLE
chore: upgrade cli-style

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,4 +1,4 @@
-titleOnly: true
+titleOnly: false
 commitsOnly: false
-titleAndCommits: false
-allowMergeCommits: false
+titleAndCommits: true
+allowMergeCommits: true

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,4 +1,1 @@
-titleOnly: false
-commitsOnly: false
-titleAndCommits: true
-allowMergeCommits: true
+enabled: false

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,1 +1,4 @@
-enabled: false
+titleOnly: true
+commitsOnly: false
+titleAndCommits: false
+allowMergeCommits: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,440 +1,376 @@
 ## [4.2.3](https://github.com/dhis2/cli/compare/v4.2.2...v4.2.3) (2023-01-13)
 
-
 ### Bug Fixes
 
-* set DHIS2_HOME env var to /DHIS2_home for images pre-Jib ([4e8ce2b](https://github.com/dhis2/cli/commit/4e8ce2b00e4e8f5069ae37c2f685bef31733f0cf))
+-   set DHIS2_HOME env var to /DHIS2_home for images pre-Jib ([4e8ce2b](https://github.com/dhis2/cli/commit/4e8ce2b00e4e8f5069ae37c2f685bef31733f0cf))
 
 ## [4.2.2](https://github.com/dhis2/cli/compare/v4.2.1...v4.2.2) (2022-01-10)
 
-
 ### Bug Fixes
 
-* bump cli-helpers-engine for all packages ([#524](https://github.com/dhis2/cli/issues/524)) ([f651b4a](https://github.com/dhis2/cli/commit/f651b4a4db4136155760347027c9dea0ed1a642e))
+-   bump cli-helpers-engine for all packages ([#524](https://github.com/dhis2/cli/issues/524)) ([f651b4a](https://github.com/dhis2/cli/commit/f651b4a4db4136155760347027c9dea0ed1a642e))
 
 ## [4.2.1](https://github.com/dhis2/cli/compare/v4.2.0...v4.2.1) (2022-01-06)
 
-
 ### Bug Fixes
 
-* **main:** bump cli-helpers-engine to fix undefined project root issue ([#522](https://github.com/dhis2/cli/issues/522)) ([b869c72](https://github.com/dhis2/cli/commit/b869c72bf3557d02ea5204b155bd991dc3e51cec))
+-   **main:** bump cli-helpers-engine to fix undefined project root issue ([#522](https://github.com/dhis2/cli/issues/522)) ([b869c72](https://github.com/dhis2/cli/commit/b869c72bf3557d02ea5204b155bd991dc3e51cec))
 
 # [4.2.0](https://github.com/dhis2/cli/compare/v4.1.0...v4.2.0) (2021-11-29)
 
-
 ### Bug Fixes
 
-* **deps:** bump @dhis2/cli-utils-docsite from 3.0.0 to 3.1.2 [defer release] ([#468](https://github.com/dhis2/cli/issues/468)) ([6c3a69d](https://github.com/dhis2/cli/commit/6c3a69d852dc57aad7714e50da3492dbf39a5c67))
-
+-   **deps:** bump @dhis2/cli-utils-docsite from 3.0.0 to 3.1.2 [defer release] ([#468](https://github.com/dhis2/cli/issues/468)) ([6c3a69d](https://github.com/dhis2/cli/commit/6c3a69d852dc57aad7714e50da3492dbf39a5c67))
 
 ### Features
 
-* **cli:** prefer project-local tools ([50e1eae](https://github.com/dhis2/cli/commit/50e1eaec3c3107e2134386589efca68f5ecb8965))
-* **deps:** bump @dhis2/cli-utils-cypress from 8.0.1 to 9.0.1 [defer release] ([#513](https://github.com/dhis2/cli/issues/513)) ([ea03992](https://github.com/dhis2/cli/commit/ea0399223feb6e344124c806ee79eae3f6fb85ce))
+-   **cli:** prefer project-local tools ([50e1eae](https://github.com/dhis2/cli/commit/50e1eaec3c3107e2134386589efca68f5ecb8965))
+-   **deps:** bump @dhis2/cli-utils-cypress from 8.0.1 to 9.0.1 [defer release] ([#513](https://github.com/dhis2/cli/issues/513)) ([ea03992](https://github.com/dhis2/cli/commit/ea0399223feb6e344124c806ee79eae3f6fb85ce))
 
 # [4.1.0](https://github.com/dhis2/cli/compare/v4.0.5...v4.1.0) (2021-11-10)
 
-
 ### Features
 
-* **deps:** bump @dhis2/cli-app-scripts from 7.1.0 to 8.3.0 [defer release] ([#508](https://github.com/dhis2/cli/issues/508)) ([288039e](https://github.com/dhis2/cli/commit/288039e5e0f2cea1ce20627871a38668f75fe77b))
+-   **deps:** bump @dhis2/cli-app-scripts from 7.1.0 to 8.3.0 [defer release] ([#508](https://github.com/dhis2/cli/issues/508)) ([288039e](https://github.com/dhis2/cli/commit/288039e5e0f2cea1ce20627871a38668f75fe77b))
 
 ## [4.0.5](https://github.com/dhis2/cli/compare/v4.0.4...v4.0.5) (2021-07-05)
 
-
 ### Bug Fixes
 
-* **deps:** update semantic-release dependencies ([a3d6aef](https://github.com/dhis2/cli/commit/a3d6aefda0dcd6792dce92149ba79d6aeecab040))
+-   **deps:** update semantic-release dependencies ([a3d6aef](https://github.com/dhis2/cli/commit/a3d6aefda0dcd6792dce92149ba79d6aeecab040))
 
 ## [4.0.4](https://github.com/dhis2/cli/compare/v4.0.3...v4.0.4) (2021-06-23)
 
-
 ### Bug Fixes
 
-* **utils:** manage versions on private packages when not publishing to npm ([1a305f9](https://github.com/dhis2/cli/commit/1a305f9))
+-   **utils:** manage versions on private packages when not publishing to npm ([1a305f9](https://github.com/dhis2/cli/commit/1a305f9))
 
 ## [4.0.3](https://github.com/dhis2/cli/compare/v4.0.2...v4.0.3) (2021-06-23)
 
-
 ### Bug Fixes
 
-* **release:** always update package.json version ([97fbfd6](https://github.com/dhis2/cli/commit/97fbfd6))
+-   **release:** always update package.json version ([97fbfd6](https://github.com/dhis2/cli/commit/97fbfd6))
 
 ## [4.0.2](https://github.com/dhis2/cli/compare/v4.0.1...v4.0.2) (2021-06-16)
 
-
 ### Bug Fixes
 
-* **semantic-release:** pin version to 16 ([254b55c](https://github.com/dhis2/cli/commit/254b55c))
+-   **semantic-release:** pin version to 16 ([254b55c](https://github.com/dhis2/cli/commit/254b55c))
 
 ## [4.0.1](https://github.com/dhis2/cli/compare/v4.0.0...v4.0.1) (2021-06-14)
 
-
 ### Bug Fixes
 
-* **deps:** update cli-style to work in non-project context ([adf329e](https://github.com/dhis2/cli/commit/adf329e))
-* **utils:** include cypress utilities ([df0e5ce](https://github.com/dhis2/cli/commit/df0e5ce))
+-   **deps:** update cli-style to work in non-project context ([adf329e](https://github.com/dhis2/cli/commit/adf329e))
+-   **utils:** include cypress utilities ([df0e5ce](https://github.com/dhis2/cli/commit/df0e5ce))
 
 # [4.0.0](https://github.com/dhis2/cli/compare/v3.1.0...v4.0.0) (2021-06-14)
 
-
 ### chore
 
-* remove node 10 support ([c35761e](https://github.com/dhis2/cli/commit/c35761e))
-
+-   remove node 10 support ([c35761e](https://github.com/dhis2/cli/commit/c35761e))
 
 ### BREAKING CHANGES
 
-* New minimum version for NodeJS is 12.x.
+-   New minimum version for NodeJS is 12.x.
 
 # [3.1.0](https://github.com/dhis2/cli/compare/v3.0.6...v3.1.0) (2021-02-02)
 
-
 ### Features
 
-* **codemods:** add d2-utils-codemods ([#397](https://github.com/dhis2/cli/issues/397)) ([0afbfe8](https://github.com/dhis2/cli/commit/0afbfe8))
+-   **codemods:** add d2-utils-codemods ([#397](https://github.com/dhis2/cli/issues/397)) ([0afbfe8](https://github.com/dhis2/cli/commit/0afbfe8))
 
 ## [3.0.6](https://github.com/dhis2/cli/compare/v3.0.5...v3.0.6) (2020-11-06)
 
-
 ### Bug Fixes
 
-* cut release to finish migration to jira ([2c671d7](https://github.com/dhis2/cli/commit/2c671d7))
+-   cut release to finish migration to jira ([2c671d7](https://github.com/dhis2/cli/commit/2c671d7))
 
 ## [3.0.5](https://github.com/dhis2/cli/compare/v3.0.4...v3.0.5) (2020-09-10)
 
-
 ### Bug Fixes
 
-* **deps:** bump @dhis2/cli-app-scripts from 4.0.0 to 5.2.0 ([#367](https://github.com/dhis2/cli/issues/367)) ([bc9eceb](https://github.com/dhis2/cli/commit/bc9eceb))
+-   **deps:** bump @dhis2/cli-app-scripts from 4.0.0 to 5.2.0 ([#367](https://github.com/dhis2/cli/issues/367)) ([bc9eceb](https://github.com/dhis2/cli/commit/bc9eceb))
 
 ## [3.0.4](https://github.com/dhis2/cli/compare/v3.0.3...v3.0.4) (2020-05-05)
 
-
 ### Bug Fixes
 
-* use new location for sample database downloads ([#327](https://github.com/dhis2/cli/issues/327)) ([d571de4](https://github.com/dhis2/cli/commit/d571de4))
+-   use new location for sample database downloads ([#327](https://github.com/dhis2/cli/issues/327)) ([d571de4](https://github.com/dhis2/cli/commit/d571de4))
 
 ## [3.0.3](https://github.com/dhis2/cli/compare/v3.0.2...v3.0.3) (2020-04-06)
 
-
 ### Bug Fixes
 
-* add cli-table3 as d2-cluster dependency ([bd84e12](https://github.com/dhis2/cli/commit/bd84e12))
+-   add cli-table3 as d2-cluster dependency ([bd84e12](https://github.com/dhis2/cli/commit/bd84e12))
 
 ## [3.0.2](https://github.com/dhis2/cli/compare/v3.0.1...v3.0.2) (2020-04-03)
 
-
 ### Bug Fixes
 
-* don't set DHIS2_CORE_CONFIG to undefined, it needs to be unset ([21b467a](https://github.com/dhis2/cli/commit/21b467a))
+-   don't set DHIS2_CORE_CONFIG to undefined, it needs to be unset ([21b467a](https://github.com/dhis2/cli/commit/21b467a))
 
 ## [3.0.1](https://github.com/dhis2/cli/compare/v3.0.0...v3.0.1) (2020-04-03)
 
-
 ### Bug Fixes
 
-* **release:** avoid picking a prop from undefined ([5e9f48e](https://github.com/dhis2/cli/commit/5e9f48e))
+-   **release:** avoid picking a prop from undefined ([5e9f48e](https://github.com/dhis2/cli/commit/5e9f48e))
 
 # [3.0.0](https://github.com/dhis2/cli/compare/v2.9.1...v3.0.0) (2020-04-02)
 
-
 ### chore
 
-* require node >=10 ([ee2a64b](https://github.com/dhis2/cli/commit/ee2a64b))
-
+-   require node >=10 ([ee2a64b](https://github.com/dhis2/cli/commit/ee2a64b))
 
 ### Features
 
-* **utils:** add cypress subcommand ([96c5b86](https://github.com/dhis2/cli/commit/96c5b86))
-
+-   **utils:** add cypress subcommand ([96c5b86](https://github.com/dhis2/cli/commit/96c5b86))
 
 ### BREAKING CHANGES
 
-* Require Node version 10 or later.
+-   Require Node version 10 or later.
 
 ## [2.9.1](https://github.com/dhis2/cli/compare/v2.9.0...v2.9.1) (2020-03-15)
 
-
 ### Bug Fixes
 
-* **release:** fix changelog ([f6b7a0d](https://github.com/dhis2/cli/commit/f6b7a0d))
+-   **release:** fix changelog ([f6b7a0d](https://github.com/dhis2/cli/commit/f6b7a0d))
 
 # [2.9.0](https://github.com/dhis2/cli/compare/v2.8.1...v2.9.0) (2020-03-15)
 
-
 ### Bug Fixes
 
-* release with the internal changes, not the npm package ([6763800](https://github.com/dhis2/cli/commit/6763800))
-
+-   release with the internal changes, not the npm package ([6763800](https://github.com/dhis2/cli/commit/6763800))
 
 ### Features
 
-* **release:** support distribution tags and custom release user info ([#292](https://github.com/dhis2/cli/issues/292)) ([7e59cf5](https://github.com/dhis2/cli/commit/7e59cf5))
+-   **release:** support distribution tags and custom release user info ([#292](https://github.com/dhis2/cli/issues/292)) ([7e59cf5](https://github.com/dhis2/cli/commit/7e59cf5))
 
 ## [2.8.1](https://github.com/dhis2/cli/compare/v2.8.0...v2.8.1) (2020-01-20)
 
-
 ### Bug Fixes
 
-* **docs:** format link correctly ([#255](https://github.com/dhis2/cli/issues/255)) ([8626546](https://github.com/dhis2/cli/commit/8626546))
+-   **docs:** format link correctly ([#255](https://github.com/dhis2/cli/issues/255)) ([8626546](https://github.com/dhis2/cli/commit/8626546))
 
 # [2.8.0](https://github.com/dhis2/cli/compare/v2.7.0...v2.8.0) (2020-01-09)
 
-
 ### Features
 
-* **cluster:** add option to pass in path to custom dhis.conf ([#236](https://github.com/dhis2/cli/issues/236)) ([80f4cd5](https://github.com/dhis2/cli/commit/80f4cd5))
+-   **cluster:** add option to pass in path to custom dhis.conf ([#236](https://github.com/dhis2/cli/issues/236)) ([80f4cd5](https://github.com/dhis2/cli/commit/80f4cd5))
 
 # [2.7.0](https://github.com/dhis2/cli/compare/v2.6.1...v2.7.0) (2019-11-26)
 
-
 ### Features
 
-* upgrade @dhis2/cli-style to 5.0.2, don't auto-format code in pre-commit hook ([#208](https://github.com/dhis2/cli/issues/208)) ([c2f8eea](https://github.com/dhis2/cli/commit/c2f8eea))
+-   upgrade @dhis2/cli-style to 5.0.2, don't auto-format code in pre-commit hook ([#208](https://github.com/dhis2/cli/issues/208)) ([c2f8eea](https://github.com/dhis2/cli/commit/c2f8eea))
 
 ## [2.6.1](https://github.com/dhis2/cli/compare/v2.6.0...v2.6.1) (2019-11-21)
 
-
 ### Bug Fixes
 
-* **deps:** bump @dhis2/cli-app-scripts from 1.5.5 to 1.5.9 ([#195](https://github.com/dhis2/cli/issues/195)) ([35f9487](https://github.com/dhis2/cli/commit/35f9487))
+-   **deps:** bump @dhis2/cli-app-scripts from 1.5.5 to 1.5.9 ([#195](https://github.com/dhis2/cli/issues/195)) ([35f9487](https://github.com/dhis2/cli/commit/35f9487))
 
 # [2.6.0](https://github.com/dhis2/cli/compare/v2.5.0...v2.6.0) (2019-10-24)
 
-
 ### Features
 
-* add i18n modernize to create new translation files from old ones ([#113](https://github.com/dhis2/cli/issues/113)) ([4e52e32](https://github.com/dhis2/cli/commit/4e52e32))
+-   add i18n modernize to create new translation files from old ones ([#113](https://github.com/dhis2/cli/issues/113)) ([4e52e32](https://github.com/dhis2/cli/commit/4e52e32))
 
 # [2.5.0](https://github.com/dhis2/cli/compare/v2.4.0...v2.5.0) (2019-10-16)
 
-
 ### Features
 
-* allow defer-release keyword in commit messages ([#161](https://github.com/dhis2/cli/issues/161)) ([ef6b385](https://github.com/dhis2/cli/commit/ef6b385))
+-   allow defer-release keyword in commit messages ([#161](https://github.com/dhis2/cli/issues/161)) ([ef6b385](https://github.com/dhis2/cli/commit/ef6b385))
 
 # [2.4.0](https://github.com/dhis2/cli/compare/v2.3.1...v2.4.0) (2019-10-09)
 
-
 ### Bug Fixes
 
-* **deps:** bump @dhis2/cli-style from 4.1.2 to 4.1.3 ([#157](https://github.com/dhis2/cli/issues/157)) [skip ci] ([957fd62](https://github.com/dhis2/cli/commit/957fd62))
-
+-   **deps:** bump @dhis2/cli-style from 4.1.2 to 4.1.3 ([#157](https://github.com/dhis2/cli/issues/157)) [skip ci] ([957fd62](https://github.com/dhis2/cli/commit/957fd62))
 
 ### Features
 
-* **deps:** bump @dhis2/cli-app-scripts from 1.4.4 to 1.5.3 ([#156](https://github.com/dhis2/cli/issues/156)) ([2ae6bf7](https://github.com/dhis2/cli/commit/2ae6bf7))
+-   **deps:** bump @dhis2/cli-app-scripts from 1.4.4 to 1.5.3 ([#156](https://github.com/dhis2/cli/issues/156)) ([2ae6bf7](https://github.com/dhis2/cli/commit/2ae6bf7))
 
 ## [2.3.1](https://github.com/dhis2/cli/compare/v2.3.0...v2.3.1) (2019-09-27)
 
-
 ### Bug Fixes
 
-* bump @dhis2/cli-app-scripts from 1.3.1 to 1.4.4 ([#145](https://github.com/dhis2/cli/issues/145)) ([d10842f](https://github.com/dhis2/cli/commit/d10842f))
+-   bump @dhis2/cli-app-scripts from 1.3.1 to 1.4.4 ([#145](https://github.com/dhis2/cli/issues/145)) ([d10842f](https://github.com/dhis2/cli/commit/d10842f))
 
 # [2.3.0](https://github.com/dhis2/cli/compare/v2.2.2...v2.3.0) (2019-09-17)
 
-
 ### Features
 
-* schema differ ([#43](https://github.com/dhis2/cli/issues/43)) ([c46e343](https://github.com/dhis2/cli/commit/c46e343)), closes [#51](https://github.com/dhis2/cli/issues/51)
+-   schema differ ([#43](https://github.com/dhis2/cli/issues/43)) ([c46e343](https://github.com/dhis2/cli/commit/c46e343)), closes [#51](https://github.com/dhis2/cli/issues/51)
 
 ## [2.2.2](https://github.com/dhis2/cli/compare/v2.2.1...v2.2.2) (2019-09-17)
 
-
 ### Bug Fixes
 
-* don't swallow release command errors ([#131](https://github.com/dhis2/cli/issues/131)) ([8a09d32](https://github.com/dhis2/cli/commit/8a09d32))
+-   don't swallow release command errors ([#131](https://github.com/dhis2/cli/issues/131)) ([8a09d32](https://github.com/dhis2/cli/commit/8a09d32))
 
 ## [2.2.1](https://github.com/dhis2/cli/compare/v2.2.0...v2.2.1) (2019-09-06)
 
-
 ### Bug Fixes
 
-* correctly normalize compose project name ([#129](https://github.com/dhis2/cli/issues/129)) ([12129e7](https://github.com/dhis2/cli/commit/12129e7))
+-   correctly normalize compose project name ([#129](https://github.com/dhis2/cli/issues/129)) ([12129e7](https://github.com/dhis2/cli/commit/12129e7))
 
 # [2.2.0](https://github.com/dhis2/cli/compare/v2.1.3...v2.2.0) (2019-08-29)
 
-
 ### Features
 
-* add support for d2-app-scripts and d2-utils-docsite ([#121](https://github.com/dhis2/cli/issues/121)) ([4b39415](https://github.com/dhis2/cli/commit/4b39415))
+-   add support for d2-app-scripts and d2-utils-docsite ([#121](https://github.com/dhis2/cli/issues/121)) ([4b39415](https://github.com/dhis2/cli/commit/4b39415))
 
 ## [2.1.3](https://github.com/dhis2/cli/compare/v2.1.2...v2.1.3) (2019-08-27)
 
-
 ### Bug Fixes
 
-* properly handle workspaces.packages arrays ([1a5929a](https://github.com/dhis2/cli/commit/1a5929a))
+-   properly handle workspaces.packages arrays ([1a5929a](https://github.com/dhis2/cli/commit/1a5929a))
 
 ## [2.1.2](https://github.com/dhis2/cli/compare/v2.1.1...v2.1.2) (2019-08-27)
 
-
 ### Bug Fixes
 
-* missing import ([06d22bc](https://github.com/dhis2/cli/commit/06d22bc))
+-   missing import ([06d22bc](https://github.com/dhis2/cli/commit/06d22bc))
 
 ## [2.1.1](https://github.com/dhis2/cli/compare/v2.1.0...v2.1.1) (2019-08-25)
 
-
 ### Bug Fixes
 
-* improve cluster list formatting ([#119](https://github.com/dhis2/cli/issues/119)) ([8b6411c](https://github.com/dhis2/cli/commit/8b6411c))
+-   improve cluster list formatting ([#119](https://github.com/dhis2/cli/issues/119)) ([8b6411c](https://github.com/dhis2/cli/commit/8b6411c))
 
 # [2.1.0](https://github.com/dhis2/cli/compare/v2.0.0...v2.1.0) (2019-08-24)
 
-
 ### Features
 
-* add `cluster list` command ([#118](https://github.com/dhis2/cli/issues/118)) ([b3b1e6d](https://github.com/dhis2/cli/commit/b3b1e6d))
+-   add `cluster list` command ([#118](https://github.com/dhis2/cli/issues/118)) ([b3b1e6d](https://github.com/dhis2/cli/commit/b3b1e6d))
 
 # [2.0.0](https://github.com/dhis2/cli/compare/v1.4.0...v2.0.0) (2019-07-15)
 
-
 ### chore
 
-* prepare 2.0 of d2 ([#100](https://github.com/dhis2/cli/issues/100)) ([52d4f00](https://github.com/dhis2/cli/commit/52d4f00))
-
+-   prepare 2.0 of d2 ([#100](https://github.com/dhis2/cli/issues/100)) ([52d4f00](https://github.com/dhis2/cli/commit/52d4f00))
 
 ### BREAKING CHANGES
 
-* Remove deprecated `d2-cluster seed` command, and update `d2-style` to 4.1.0.
+-   Remove deprecated `d2-cluster seed` command, and update `d2-style` to 4.1.0.
 
-- For changelog of what has changed with cli-style, see https://github.com/dhis2/cli-style/blob/master/CHANGELOG.md#breaking-changes for a list of changes.
+*   For changelog of what has changed with cli-style, see https://github.com/dhis2/cli-style/blob/master/CHANGELOG.md#breaking-changes for a list of changes.
 
-- `d2-cluster seed` has been deprecated in favour of `d2-cluster db restore`, see `d2 cluster db --help` for more information on usage.
+*   `d2-cluster seed` has been deprecated in favour of `d2-cluster db restore`, see `d2 cluster db --help` for more information on usage.
 
 # [1.4.0](https://github.com/dhis2/cli/compare/v1.3.0...v1.4.0) (2019-07-02)
 
-
 ### Features
 
-* add cluster db commands, update images on up, add compose cmd ([#95](https://github.com/dhis2/cli/issues/95)) ([7dd4fc1](https://github.com/dhis2/cli/commit/7dd4fc1))
+-   add cluster db commands, update images on up, add compose cmd ([#95](https://github.com/dhis2/cli/issues/95)) ([7dd4fc1](https://github.com/dhis2/cli/commit/7dd4fc1))
 
 # [1.3.0](https://github.com/dhis2/cli/compare/v1.2.4...v1.3.0) (2019-07-01)
 
-
 ### Features
 
-* decouple configs from cluster ([#53](https://github.com/dhis2/cli/issues/53)) ([e5b40af](https://github.com/dhis2/cli/commit/e5b40af))
+-   decouple configs from cluster ([#53](https://github.com/dhis2/cli/issues/53)) ([e5b40af](https://github.com/dhis2/cli/commit/e5b40af))
 
 ## [1.2.4](https://github.com/dhis2/cli/compare/v1.2.3...v1.2.4) (2019-06-13)
 
-
 ### Bug Fixes
 
-* use dhis2/docker-compose instead of amcgee/dhis2-backend as default ([#61](https://github.com/dhis2/cli/issues/61)) ([85d708f](https://github.com/dhis2/cli/commit/85d708f))
+-   use dhis2/docker-compose instead of amcgee/dhis2-backend as default ([#61](https://github.com/dhis2/cli/issues/61)) ([85d708f](https://github.com/dhis2/cli/commit/85d708f))
 
 ## [1.2.3](https://github.com/dhis2/cli/compare/v1.2.2...v1.2.3) (2019-06-12)
 
-
 ### Bug Fixes
 
-* avoid double parsing of arguments ([#64](https://github.com/dhis2/cli/issues/64)) ([b616152](https://github.com/dhis2/cli/commit/b616152))
+-   avoid double parsing of arguments ([#64](https://github.com/dhis2/cli/issues/64)) ([b616152](https://github.com/dhis2/cli/commit/b616152))
 
 ## [1.2.2](https://github.com/dhis2/cli/compare/v1.2.1...v1.2.2) (2019-05-27)
 
-
 ### Bug Fixes
 
-* use the resolved db dump url ([#56](https://github.com/dhis2/cli/issues/56)) ([0f26ad1](https://github.com/dhis2/cli/commit/0f26ad1))
+-   use the resolved db dump url ([#56](https://github.com/dhis2/cli/issues/56)) ([0f26ad1](https://github.com/dhis2/cli/commit/0f26ad1))
 
 ## [1.2.1](https://github.com/dhis2/cli/compare/v1.2.0...v1.2.1) (2019-05-27)
 
-
 ### Bug Fixes
 
-* resolve dockerComposeRepository from defaults if cluster undefined ([#55](https://github.com/dhis2/cli/issues/55)) ([39fc0c7](https://github.com/dhis2/cli/commit/39fc0c7))
+-   resolve dockerComposeRepository from defaults if cluster undefined ([#55](https://github.com/dhis2/cli/issues/55)) ([39fc0c7](https://github.com/dhis2/cli/commit/39fc0c7))
 
 # [1.2.0](https://github.com/dhis2/cli/compare/v1.1.0...v1.2.0) (2019-05-27)
 
-
 ### Features
 
-* support official docker images ([#54](https://github.com/dhis2/cli/issues/54)) ([8e2a6da](https://github.com/dhis2/cli/commit/8e2a6da))
+-   support official docker images ([#54](https://github.com/dhis2/cli/issues/54)) ([8e2a6da](https://github.com/dhis2/cli/commit/8e2a6da))
 
 # [1.1.0](https://github.com/dhis2/cli/compare/v1.0.5...v1.1.0) (2019-05-23)
 
-
 ### Features
 
-* decouple tag, name, and version ([#46](https://github.com/dhis2/cli/issues/46)) ([28e88e4](https://github.com/dhis2/cli/commit/28e88e4))
+-   decouple tag, name, and version ([#46](https://github.com/dhis2/cli/issues/46)) ([28e88e4](https://github.com/dhis2/cli/commit/28e88e4))
 
 ## [1.0.5](https://github.com/dhis2/cli/compare/v1.0.4...v1.0.5) (2019-05-14)
 
-
 ### Bug Fixes
 
-* update @dhis2/cli style 3.2.1 ([#49](https://github.com/dhis2/cli/issues/49)) ([c375f8d](https://github.com/dhis2/cli/commit/c375f8d)), closes [#48](https://github.com/dhis2/cli/issues/48) [#48](https://github.com/dhis2/cli/issues/48)
+-   update @dhis2/cli style 3.2.1 ([#49](https://github.com/dhis2/cli/issues/49)) ([c375f8d](https://github.com/dhis2/cli/commit/c375f8d)), closes [#48](https://github.com/dhis2/cli/issues/48) [#48](https://github.com/dhis2/cli/issues/48)
 
 ## [1.0.4](https://github.com/dhis2/cli/compare/v1.0.3...v1.0.4) (2019-05-14)
 
-
 ### Bug Fixes
 
-* update @dhis2/cli-helpers-engine in group default to the latest version 🚀 ([#47](https://github.com/dhis2/cli/issues/47)) ([6139000](https://github.com/dhis2/cli/commit/6139000))
+-   update @dhis2/cli-helpers-engine in group default to the latest version 🚀 ([#47](https://github.com/dhis2/cli/issues/47)) ([6139000](https://github.com/dhis2/cli/commit/6139000))
 
 ## [1.0.3](https://github.com/dhis2/cli/compare/v1.0.2...v1.0.3) (2019-05-13)
 
-
 ### Bug Fixes
 
-* **cluster:** expose the version as an environment variable in the context ([#39](https://github.com/dhis2/cli/issues/39)) ([7e8e8dd](https://github.com/dhis2/cli/commit/7e8e8dd))
+-   **cluster:** expose the version as an environment variable in the context ([#39](https://github.com/dhis2/cli/issues/39)) ([7e8e8dd](https://github.com/dhis2/cli/commit/7e8e8dd))
 
 ## [1.0.2](https://github.com/dhis2/cli/compare/v1.0.1...v1.0.2) (2019-03-28)
 
-
 ### Bug Fixes
 
-* upgrade @dhis2/cli-helpers-engine and @dhis2/cli-style ([#35](https://github.com/dhis2/cli/issues/35)) ([251ac22](https://github.com/dhis2/cli/commit/251ac22))
+-   upgrade @dhis2/cli-helpers-engine and @dhis2/cli-style ([#35](https://github.com/dhis2/cli/issues/35)) ([251ac22](https://github.com/dhis2/cli/commit/251ac22))
 
 ## [1.0.1](https://github.com/dhis2/cli/compare/v1.0.0...v1.0.1) (2019-03-27)
 
-
 ### Bug Fixes
 
-* seed from file variable name was misspelled ([#33](https://github.com/dhis2/cli/issues/33)) ([6109c95](https://github.com/dhis2/cli/commit/6109c95))
+-   seed from file variable name was misspelled ([#33](https://github.com/dhis2/cli/issues/33)) ([6109c95](https://github.com/dhis2/cli/commit/6109c95))
 
 # [1.0.0](https://github.com/dhis2/cli/compare/v0.14.0...v1.0.0) (2019-03-25)
 
-
 ### Features
 
-* upgrade cli-helpers-engine and cli-style dependencies ([#32](https://github.com/dhis2/cli/issues/32)) ([21c78dd](https://github.com/dhis2/cli/commit/21c78dd))
-
+-   upgrade cli-helpers-engine and cli-style dependencies ([#32](https://github.com/dhis2/cli/issues/32)) ([21c78dd](https://github.com/dhis2/cli/commit/21c78dd))
 
 ### BREAKING CHANGES
 
-* cut major version 1.0.0
+-   cut major version 1.0.0
 
-* chore: update cli-helpers-engine and cli-style dependencies
+-   chore: update cli-helpers-engine and cli-style dependencies
 
-* chore: let greenkeeper watch the create cli template
+-   chore: let greenkeeper watch the create cli template
 
 # [0.14.0](https://github.com/dhis2/cli/compare/v0.13.0...v0.14.0) (2019-03-25)
 
-
 ### Features
 
-* one dot oh! ([#28](https://github.com/dhis2/cli/issues/28)) ([207ae93](https://github.com/dhis2/cli/commit/207ae93))
+-   one dot oh! ([#28](https://github.com/dhis2/cli/issues/28)) ([207ae93](https://github.com/dhis2/cli/commit/207ae93))
 
 # [0.13.0](https://github.com/dhis2/cli/compare/v0.12.1...v0.13.0) (2019-03-25)
 
-
 ### Bug Fixes
 
-* don't update the package.json version before npm stage ([#25](https://github.com/dhis2/cli/issues/25)) ([5909f78](https://github.com/dhis2/cli/commit/5909f78))
-
+-   don't update the package.json version before npm stage ([#25](https://github.com/dhis2/cli/issues/25)) ([5909f78](https://github.com/dhis2/cli/commit/5909f78))
 
 ### Features
 
-* semantic release update deps ([#24](https://github.com/dhis2/cli/issues/24)) ([d2c155e](https://github.com/dhis2/cli/commit/d2c155e))
+-   semantic release update deps ([#24](https://github.com/dhis2/cli/issues/24)) ([d2c155e](https://github.com/dhis2/cli/commit/d2c155e))
 
 ## [0.12.1](https://github.com/dhis2/cli/compare/v0.12.0...v0.12.1) (2019-03-22)
 
-
 ### Bug Fixes
 
-* add scripts subcommand ([#23](https://github.com/dhis2/cli/issues/23)) ([bb36a22](https://github.com/dhis2/cli/commit/bb36a22))
-* publish multiple packages from inside a package ([#22](https://github.com/dhis2/cli/issues/22)) ([6012782](https://github.com/dhis2/cli/commit/6012782))
+-   add scripts subcommand ([#23](https://github.com/dhis2/cli/issues/23)) ([bb36a22](https://github.com/dhis2/cli/commit/bb36a22))
+-   publish multiple packages from inside a package ([#22](https://github.com/dhis2/cli/issues/22)) ([6012782](https://github.com/dhis2/cli/commit/6012782))

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     ],
     "license": "BSD-3-Clause",
     "devDependencies": {
-        "@dhis2/cli-style": "^9.0.1",
-        "@dhis2/cli-utils-docsite": "^3.1.2",
+        "@dhis2/cli-style": "^10.5.1",
+        "@dhis2/cli-utils-docsite": "^3.2.0",
         "tape": "^4.13.2",
         "tape-await": "^0.1.2"
     },
@@ -26,5 +26,8 @@
             "name": "DHIS2 CLI",
             "description": "A unified CLI for DHIS2 development workflows."
         }
+    },
+    "resolutions": {
+        "@ls-lint/ls-lint": "2.0.1"
     }
 }

--- a/packages/app/src/commands/i18n.js
+++ b/packages/app/src/commands/i18n.js
@@ -2,5 +2,5 @@ const { namespace } = require('@dhis2/cli-helpers-engine')
 
 module.exports = namespace('i18n', {
     description: 'Handle translations in apps',
-    builder: yargs => yargs.commandDir('i18n'),
+    builder: (yargs) => yargs.commandDir('i18n'),
 })

--- a/packages/app/src/helpers/modernize/checkRequirements.js
+++ b/packages/app/src/helpers/modernize/checkRequirements.js
@@ -43,7 +43,7 @@ const checkMainTranslationFilePresent = (
     primaryLanguage,
     translationFiles
 ) => {
-    const mainTranslationFile = translationFiles.find(file =>
+    const mainTranslationFile = translationFiles.find((file) =>
         file.match(`i18n_module_${primaryLanguage}.properties`)
     )
     const mainTranslationFilePath = path.join(inDir, mainTranslationFile)

--- a/packages/app/src/helpers/modernize/createNewTranslationFiles.js
+++ b/packages/app/src/helpers/modernize/createNewTranslationFiles.js
@@ -115,7 +115,7 @@ const createNewTranslationFiles = ({
                     } else {
                         newContents += `msgid ""\n`
                         const newLines = splitTranslation(originalTranslation)
-                        newLines.forEach(translationPart => {
+                        newLines.forEach((translationPart) => {
                             newContents += `"${unescape(translationPart)}"\n`
                         })
                     }
@@ -125,7 +125,7 @@ const createNewTranslationFiles = ({
                     } else {
                         newContents += `msgstr ""\n`
                         const newLines = splitTranslation(translation)
-                        newLines.forEach(translationPart => {
+                        newLines.forEach((translationPart) => {
                             newContents += `"${unescape(translationPart)}"\n`
                         })
                     }

--- a/packages/app/src/helpers/modernize/deleteLegacyFiles.js
+++ b/packages/app/src/helpers/modernize/deleteLegacyFiles.js
@@ -8,7 +8,7 @@ const { reporter } = require('@dhis2/cli-helpers-engine')
  * @returns {void}
  */
 const deleteLegacyFiles = ({ translationFiles, languagesToTransform }) => {
-    translationFiles.forEach(file => {
+    translationFiles.forEach((file) => {
         const language = file.replace(/i18n_module_|.properties/g, '')
 
         if (

--- a/packages/app/src/helpers/modernize/generateTranslationMappings.js
+++ b/packages/app/src/helpers/modernize/generateTranslationMappings.js
@@ -21,7 +21,7 @@ const generateTranslationMappings = ({
         })
         const lines = contents
             .split('\n')
-            .filter(line => line !== '' && !line[0].match(/\s*#/))
+            .filter((line) => line !== '' && !line[0].match(/\s*#/))
 
         if (
             languagesToTransform.length &&

--- a/packages/app/src/helpers/modernize/getTemplates.js
+++ b/packages/app/src/helpers/modernize/getTemplates.js
@@ -1,7 +1,7 @@
 const fs = require('fs')
 const path = require('path')
 
-const getTemplateMainLanguage = creationDate => {
+const getTemplateMainLanguage = (creationDate) => {
     const template = fs.readFileSync(
         path.join(__dirname, 'main_language.template'),
         { encoding: 'utf8' }

--- a/packages/app/src/helpers/modernize/getTranslationFileNames.js
+++ b/packages/app/src/helpers/modernize/getTranslationFileNames.js
@@ -4,7 +4,7 @@ const {
     checkMainTranslationFilePresent,
 } = require('./checkRequirements')
 
-const fileIsOldTranslationFile = fileName => fileName.match(/\.properties$/)
+const fileIsOldTranslationFile = (fileName) => fileName.match(/\.properties$/)
 
 /**
  * @param {Object} args

--- a/packages/app/src/helpers/modernize/getTranslationFileNames.js
+++ b/packages/app/src/helpers/modernize/getTranslationFileNames.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const {
     checkIODirectories,
     checkMainTranslationFilePresent,
-} = require('./checkRequirements')
+} = require('./checkRequirements.js')
 
 const fileIsOldTranslationFile = (fileName) => fileName.match(/\.properties$/)
 

--- a/packages/app/src/helpers/modernize/splitTranslation.js
+++ b/packages/app/src/helpers/modernize/splitTranslation.js
@@ -7,7 +7,7 @@ const LENGTH_TO_SPLIT_LINE_AT = 77
  * The translation needs to be split by whitespaces first in order to create the
  * correct structure of the new translation
  */
-const splitTranslation = translation =>
+const splitTranslation = (translation) =>
     translation.split(' ').reduce((parts, curSplit) => {
         const latestPart = parts[parts.length - 1]
         const latestPartEscaped = escape(latestPart)
@@ -27,7 +27,7 @@ const splitTranslation = translation =>
             return parts
         }
 
-        curSplitEscaped.match(/.{1,76}(?=(%5Cu))?/g).forEach(escapedSplit => {
+        curSplitEscaped.match(/.{1,76}(?=(%5Cu))?/g).forEach((escapedSplit) => {
             parts.push(unescape(escapedSplit))
         })
 

--- a/packages/app/src/index.js
+++ b/packages/app/src/index.js
@@ -2,7 +2,7 @@ const { namespace, createModuleLoader } = require('@dhis2/cli-helpers-engine')
 
 module.exports = namespace('app', {
     description: 'Front-end application and library commands',
-    builder: yargs => {
+    builder: (yargs) => {
         const loader = createModuleLoader({
             parentModule: __filename,
         })

--- a/packages/cluster/src/commands/compose.js
+++ b/packages/cluster/src/commands/compose.js
@@ -6,7 +6,7 @@ const {
     makeComposeProject,
     makeEnvironment,
     resolveConfiguration,
-} = require('../common')
+} = require('../common.js')
 
 const run = async function (argv) {
     const { name, _ } = argv

--- a/packages/cluster/src/commands/compose.js
+++ b/packages/cluster/src/commands/compose.js
@@ -12,7 +12,7 @@ const run = async function (argv) {
     const { name, _ } = argv
     const cfg = await resolveConfiguration(argv)
 
-    const args = _.slice(_.findIndex(x => x === 'compose') + 1)
+    const args = _.slice(_.findIndex((x) => x === 'compose') + 1)
     reporter.debug('Passing arguments to docker-compose', args)
 
     const cacheLocation = await initDockerComposeCache({

--- a/packages/cluster/src/commands/db.js
+++ b/packages/cluster/src/commands/db.js
@@ -2,7 +2,7 @@ const { namespace } = require('@dhis2/cli-helpers-engine')
 
 const command = namespace('db', {
     desc: 'Manage the database in a DHIS2 Docker cluster',
-    builder: yargs =>
+    builder: (yargs) =>
         yargs.commandDir('db_cmds').parserConfiguration({
             'parse-numbers': false,
         }),

--- a/packages/cluster/src/commands/db_cmds/backup.js
+++ b/packages/cluster/src/commands/db_cmds/backup.js
@@ -1,6 +1,9 @@
 const { reporter, tryCatchAsync } = require('@dhis2/cli-helpers-engine')
-const { initDockerComposeCache, resolveConfiguration } = require('../../common')
-const { backup } = require('../../helpers/db')
+const {
+    initDockerComposeCache,
+    resolveConfiguration,
+} = require('../../common.js')
+const { backup } = require('../../helpers/db.js')
 
 const run = async function (argv) {
     const { name, getCache, path, fat } = argv

--- a/packages/cluster/src/commands/db_cmds/restore.js
+++ b/packages/cluster/src/commands/db_cmds/restore.js
@@ -1,6 +1,9 @@
 const { reporter, tryCatchAsync } = require('@dhis2/cli-helpers-engine')
-const { initDockerComposeCache, resolveConfiguration } = require('../../common')
-const { restore } = require('../../helpers/db')
+const {
+    initDockerComposeCache,
+    resolveConfiguration,
+} = require('../../common.js')
+const { restore } = require('../../helpers/db.js')
 
 const run = async function (argv) {
     const { name, getCache } = argv

--- a/packages/cluster/src/commands/down.js
+++ b/packages/cluster/src/commands/down.js
@@ -6,7 +6,7 @@ const {
     makeComposeProject,
     makeEnvironment,
     cleanCache,
-} = require('../common')
+} = require('../common.js')
 
 const run = async function (argv) {
     const { name, clean, getCache } = argv

--- a/packages/cluster/src/commands/list.js
+++ b/packages/cluster/src/commands/list.js
@@ -2,7 +2,7 @@ const { reporter, exec, chalk } = require('@dhis2/cli-helpers-engine')
 const Table = require('cli-table3')
 const { makeComposeProject, listClusters } = require('../common')
 
-const getStatus = async cluster =>
+const getStatus = async (cluster) =>
     // TODO: check the status of the other services, not just `core`
     await exec({
         cmd: 'docker',
@@ -18,7 +18,7 @@ const getStatus = async cluster =>
         captureOut: true,
     })
 
-const formatStatus = status => {
+const formatStatus = (status) => {
     status = status.trim()
 
     if (status.length === 0) {
@@ -49,7 +49,7 @@ const run = async function (argv) {
     })
 
     await Promise.all(
-        clusters.map(async cluster => {
+        clusters.map(async (cluster) => {
             const status = await getStatus(cluster)
             table.push([
                 chalk.blue(cluster.name),

--- a/packages/cluster/src/commands/list.js
+++ b/packages/cluster/src/commands/list.js
@@ -1,6 +1,6 @@
 const { reporter, exec, chalk } = require('@dhis2/cli-helpers-engine')
 const Table = require('cli-table3')
-const { makeComposeProject, listClusters } = require('../common')
+const { makeComposeProject, listClusters } = require('../common.js')
 
 const getStatus = async (cluster) =>
     // TODO: check the status of the other services, not just `core`

--- a/packages/cluster/src/commands/logs.js
+++ b/packages/cluster/src/commands/logs.js
@@ -10,7 +10,7 @@ const {
     makeComposeProject,
     makeEnvironment,
     resolveConfiguration,
-} = require('../common')
+} = require('../common.js')
 
 const run = async function (argv) {
     const { service, name } = argv

--- a/packages/cluster/src/commands/restart.js
+++ b/packages/cluster/src/commands/restart.js
@@ -10,8 +10,8 @@ const {
     makeComposeProject,
     makeEnvironment,
     resolveConfiguration,
-} = require('../common')
-const defaults = require('../defaults')
+} = require('../common.js')
+const defaults = require('../defaults.js')
 
 const run = async function (argv) {
     const { name, service } = argv

--- a/packages/cluster/src/commands/status.js
+++ b/packages/cluster/src/commands/status.js
@@ -1,5 +1,5 @@
 const { exec, reporter } = require('@dhis2/cli-helpers-engine')
-const { makeComposeProject } = require('../common')
+const { makeComposeProject } = require('../common.js')
 
 const run = async function ({ name, ...argv }) {
     try {

--- a/packages/cluster/src/commands/up.js
+++ b/packages/cluster/src/commands/up.js
@@ -10,9 +10,9 @@ const {
     makeEnvironment,
     makeComposeProject,
     resolveConfiguration,
-} = require('../common')
-const defaults = require('../defaults')
-const { restore } = require('../helpers/db')
+} = require('../common.js')
+const defaults = require('../defaults.js')
+const { restore } = require('../helpers/db.js')
 
 const run = async function (argv) {
     const { name, seed, seedFile, update, getCache } = argv

--- a/packages/cluster/src/common.js
+++ b/packages/cluster/src/common.js
@@ -1,6 +1,6 @@
 const path = require('path')
 const { reporter } = require('@dhis2/cli-helpers-engine')
-const defaults = require('./defaults')
+const defaults = require('./defaults.js')
 
 const clusterDir = 'clusters'
 const dockerComposeCacheName = 'docker-compose'
@@ -236,7 +236,9 @@ module.exports.listClusters = async (argv) => {
     const cache = argv.getCache()
 
     const exists = await cache.exists(clusterDir)
-    if (!exists) return []
+    if (!exists) {
+        return []
+    }
 
     const stat = await cache.stat(clusterDir)
     const promises = Object.keys(stat.children)

--- a/packages/cluster/src/common.js
+++ b/packages/cluster/src/common.js
@@ -111,10 +111,10 @@ function dockerImageUsingJib(version) {
 
     const segments = version
         .split('.')
-        .map(s => s.trim())
-        .filter(s => s.length > 0) // to remove empty segments we get with versions like "2."
-        .map(n => parseInt(n, 10))
-        .filter(n => !Number.isNaN(n))
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0) // to remove empty segments we get with versions like "2."
+        .map((n) => parseInt(n, 10))
+        .filter((n) => !Number.isNaN(n))
     if (segments.length < 2) {
         throw new Error(
             `Invalid version format: '${version}'. Must be 'master' or '2.major.minor.patch'. 'patch' being optional.`
@@ -206,7 +206,7 @@ async function resolveConfiguration(argv = {}) {
 module.exports.cleanCache = async ({ cache, name }) =>
     await cache.purge(path.join(clusterDir, name))
 
-module.exports.makeEnvironment = cfg => {
+module.exports.makeEnvironment = (cfg) => {
     const env = {
         DHIS2_HOME: cfg.dhis2Home,
         DHIS2_CORE_NAME: cfg.name,
@@ -227,11 +227,12 @@ module.exports.makeEnvironment = cfg => {
 
 // This has to match the normalization done by docker-compose to reliably get container statuses
 //   from https://github.com/docker/compose/blob/c8279bc4db56f49cf2e2b80c8734ced1c418b856/compose/cli/command.py#L154
-const normalizeName = name => name.replace(/[^-_a-z0-9]/g, '')
+const normalizeName = (name) => name.replace(/[^-_a-z0-9]/g, '')
 
-module.exports.makeComposeProject = name => `d2-cluster-${normalizeName(name)}`
+module.exports.makeComposeProject = (name) =>
+    `d2-cluster-${normalizeName(name)}`
 
-module.exports.listClusters = async argv => {
+module.exports.listClusters = async (argv) => {
     const cache = argv.getCache()
 
     const exists = await cache.exists(clusterDir)
@@ -239,8 +240,8 @@ module.exports.listClusters = async argv => {
 
     const stat = await cache.stat(clusterDir)
     const promises = Object.keys(stat.children)
-        .filter(name => cache.exists(path.join(clusterDir, name)))
-        .map(name => resolveConfiguration({ name, getCache: argv.getCache }))
+        .filter((name) => cache.exists(path.join(clusterDir, name)))
+        .map((name) => resolveConfiguration({ name, getCache: argv.getCache }))
     return await Promise.all(promises)
 }
 

--- a/packages/cluster/src/helpers/db/backup.js
+++ b/packages/cluster/src/helpers/db/backup.js
@@ -1,6 +1,6 @@
 const path = require('path')
 const { reporter, exec, chalk } = require('@dhis2/cli-helpers-engine')
-const { makeComposeProject } = require('../../common')
+const { makeComposeProject } = require('../../common.js')
 
 module.exports = async ({ cacheLocation, name, path: dbPath, fat }) => {
     const destinationFile = path.resolve(dbPath)

--- a/packages/cluster/src/helpers/db/index.js
+++ b/packages/cluster/src/helpers/db/index.js
@@ -1,2 +1,2 @@
-module.exports.backup = require('./backup')
-module.exports.restore = require('./restore')
+module.exports.backup = require('./backup.js')
+module.exports.restore = require('./restore.js')

--- a/packages/cluster/src/helpers/db/restore.js
+++ b/packages/cluster/src/helpers/db/restore.js
@@ -1,6 +1,6 @@
 const path = require('path')
 const { reporter, exec, chalk } = require('@dhis2/cli-helpers-engine')
-const { makeComposeProject, substituteVersion } = require('../../common')
+const { makeComposeProject, substituteVersion } = require('../../common.js')
 
 const downloadDatabase = async ({ cache, dbVersion, update, url }) => {
     const ext = '.sql.gz' //dbUrl.endsWith('.gz') ? '.gz' : '.sql'

--- a/packages/cluster/src/index.js
+++ b/packages/cluster/src/index.js
@@ -3,7 +3,7 @@ const { namespace } = require('@dhis2/cli-helpers-engine')
 const command = namespace('cluster', {
     desc: 'Manage DHIS2 Docker clusters',
     aliases: 'c',
-    builder: yargs =>
+    builder: (yargs) =>
         yargs.commandDir('commands').parserConfiguration({
             'parse-numbers': false,
         }),

--- a/packages/cluster/tests/docker-image-jib.js
+++ b/packages/cluster/tests/docker-image-jib.js
@@ -14,7 +14,7 @@ test(`DHIS2 versions with Docker image containing /opt/dhis2`, async function (t
     ]
     t.plan(versions.length)
 
-    versions.forEach(version => t.ok(dockerImageUsingJib(version), version))
+    versions.forEach((version) => t.ok(dockerImageUsingJib(version), version))
 })
 
 test('DHIS2 versions with Docker image built containing /DHIS2_home', async function (t) {
@@ -33,14 +33,16 @@ test('DHIS2 versions with Docker image built containing /DHIS2_home', async func
     ]
     t.plan(versions.length)
 
-    versions.forEach(version => t.notOk(dockerImageUsingJib(version), version))
+    versions.forEach((version) =>
+        t.notOk(dockerImageUsingJib(version), version)
+    )
 })
 
 test('throws given invalid version', async function (t) {
     const versions = ['', '   ', '2', '2.']
     t.plan(versions.length)
 
-    versions.forEach(version =>
+    versions.forEach((version) =>
         t.throws(
             function () {
                 dockerImageUsingJib(version)

--- a/packages/cluster/tests/setup-environment.js
+++ b/packages/cluster/tests/setup-environment.js
@@ -2,7 +2,7 @@ const test = require('tape-await')
 const { makeEnvironment, resolveConfiguration } = require('../src/common.js')
 const defaults = require('../src/defaults.js')
 
-const cache = obj => ({
+const cache = (obj) => ({
     read: () => JSON.stringify(obj),
     write: () => {},
 })

--- a/packages/cluster/tests/substitute-string-keys.js
+++ b/packages/cluster/tests/substitute-string-keys.js
@@ -1,6 +1,6 @@
 const test = require('tape')
 const { makeDockerImage, substituteVersion } = require('../src/common.js')
-const defaults = require('../src/defaults')
+const defaults = require('../src/defaults.js')
 
 const template = defaults.image
 

--- a/packages/create-app/index.js
+++ b/packages/create-app/index.js
@@ -4,11 +4,11 @@ const { groupGlobalOptions } = require('@dhis2/cli-helpers-engine')
 module.exports = {
     command: 'create [type]',
     desc: 'Create a new DHIS2 front-end app',
-    builder: yargs => {
+    builder: (yargs) => {
         groupGlobalOptions(yargs)
         yargs.option('silent')
     },
-    handler: argv => {
+    handler: (argv) => {
         create.handler({
             ...argv,
             type: 'app',

--- a/packages/create/src/index.js
+++ b/packages/create/src/index.js
@@ -1,7 +1,7 @@
 const path = require('path')
 const { reporter, chalk } = require('@dhis2/cli-helpers-engine')
 const { installTemplate } = require('@dhis2/cli-helpers-template')
-const cliBuilder = require('./builders/cliBuilder')
+const cliBuilder = require('./builders/cliBuilder.js')
 
 const handler = async ({ type, name, ...argv }) => {
     if (!type) {
@@ -25,7 +25,7 @@ const handler = async ({ type, name, ...argv }) => {
             break
         }
         case 'app':
-            await require('./builders/app')({ name, ...argv })
+            await require('./builders/app.js')({ name, ...argv })
             break
         default:
             reporter.error(`Unrecognized template ${type}`)

--- a/packages/create/templates/cli/src/index.js
+++ b/packages/create/templates/cli/src/index.js
@@ -2,5 +2,5 @@ const { namespace } = require('@dhis2/cli-helpers-engine')
 
 module.exports = namespace('{{{basename}}}', {
     description: '{{{description}}}',
-    builder: yargs => yargs.commandDir('./commands'),
+    builder: (yargs) => yargs.commandDir('./commands'),
 })

--- a/packages/main/src/commands/debug.js
+++ b/packages/main/src/commands/debug.js
@@ -2,5 +2,5 @@ const { namespace } = require('@dhis2/cli-helpers-engine')
 
 module.exports = namespace('debug', {
     desc: 'Debug local d2 installation',
-    builder: yargs => yargs.commandDir('debug'),
+    builder: (yargs) => yargs.commandDir('debug'),
 })

--- a/packages/main/src/commands/debug/cache.js
+++ b/packages/main/src/commands/debug/cache.js
@@ -33,18 +33,18 @@ const parse = async ({ item = '/', getCache }) => {
     }
 }
 
-const builder = yargs => {
+const builder = (yargs) => {
     yargs.command(
         'location [item]',
         'Get the filesystem location of a cache item',
         {},
-        async argv => {
+        async (argv) => {
             const { loc } = await parse(argv)
             reporter.print(loc)
         }
     )
 
-    yargs.command('list [item]', 'List cache items', {}, async argv => {
+    yargs.command('list [item]', 'List cache items', {}, async (argv) => {
         const { item, cache, exists } = await parse(argv)
         if (!exists) {
             reporter.info(`Cached item ${chalk.bold(item)} does not exist`)
@@ -55,7 +55,7 @@ const builder = yargs => {
             head: ['Name', 'Size', 'Modified'],
         })
         if (stat.children) {
-            Object.keys(stat.children).forEach(name => {
+            Object.keys(stat.children).forEach((name) => {
                 printStats(table, name, stat.children[name])
             })
         } else {
@@ -64,19 +64,24 @@ const builder = yargs => {
         reporter.print(table)
     })
 
-    yargs.command('status [item]', 'Get cache item status', {}, async argv => {
-        const { item, exists, loc } = await parse(argv)
-        reporter.print('CACHE STATUS')
-        reporter.print(
-            `\t${chalk.green.bold(item)}\t\t${
-                exists
-                    ? `${chalk.blue.bold('EXISTS')}`
-                    : chalk.red.bold('DOES NOT EXIST')
-            }\t@ ${loc}`
-        )
-    })
+    yargs.command(
+        'status [item]',
+        'Get cache item status',
+        {},
+        async (argv) => {
+            const { item, exists, loc } = await parse(argv)
+            reporter.print('CACHE STATUS')
+            reporter.print(
+                `\t${chalk.green.bold(item)}\t\t${
+                    exists
+                        ? `${chalk.blue.bold('EXISTS')}`
+                        : chalk.red.bold('DOES NOT EXIST')
+                }\t@ ${loc}`
+            )
+        }
+    )
 
-    yargs.command('purge [item]', 'Purge cache item', {}, async argv => {
+    yargs.command('purge [item]', 'Purge cache item', {}, async (argv) => {
         const { item, isRoot, exists, cache } = await parse(argv)
         if (!exists) {
             reporter.info(`Cached item ${chalk.bold(item)} does not exist`)

--- a/packages/main/src/index.js
+++ b/packages/main/src/index.js
@@ -2,7 +2,7 @@ const { namespace, createModuleLoader } = require('@dhis2/cli-helpers-engine')
 
 const command = namespace('d2', {
     desc: 'DHIS2 CLI',
-    builder: yargs => {
+    builder: (yargs) => {
         const loader = createModuleLoader({
             parentModule: __filename,
         })

--- a/packages/utils/src/cmds/release.js
+++ b/packages/utils/src/cmds/release.js
@@ -2,7 +2,7 @@ const { existsSync } = require('fs')
 const path = require('path')
 const { reporter } = require('@dhis2/cli-helpers-engine')
 const semanticRelease = require('semantic-release')
-const getWorkspacePackages = require('../support/getWorkspacePackages')
+const getWorkspacePackages = require('../support/getWorkspacePackages.js')
 
 const packageIsPublishable = (pkgJsonPath) => {
     try {
@@ -52,7 +52,7 @@ const handler = async ({ publish }) => {
     const updateDepsPlugin =
         packages.length > 1
             ? [
-                  require('../support/semantic-release-update-deps'),
+                  require('../support/semantic-release-update-deps.js'),
                   {
                       exact: true,
                       packages,
@@ -89,7 +89,7 @@ const handler = async ({ publish }) => {
         },
     ]
 
-    const deferPlugin = require('../support/semantic-release-defer-release')
+    const deferPlugin = require('../support/semantic-release-defer-release.js')
 
     // Order matters here!
     const plugins = [

--- a/packages/utils/src/cmds/release.js
+++ b/packages/utils/src/cmds/release.js
@@ -4,7 +4,7 @@ const { reporter } = require('@dhis2/cli-helpers-engine')
 const semanticRelease = require('semantic-release')
 const getWorkspacePackages = require('../support/getWorkspacePackages')
 
-const packageIsPublishable = pkgJsonPath => {
+const packageIsPublishable = (pkgJsonPath) => {
     try {
         const pkgJson = require(pkgJsonPath)
         return !!pkgJson.name && !pkgJson.private
@@ -16,7 +16,7 @@ const packageIsPublishable = pkgJsonPath => {
 function publisher(target = '', packages) {
     switch (target.toLowerCase()) {
         case 'npm': {
-            return packages.filter(packageIsPublishable).map(pkgJsonPath => {
+            return packages.filter(packageIsPublishable).map((pkgJsonPath) => {
                 return [
                     '@semantic-release/npm',
                     {
@@ -27,7 +27,7 @@ function publisher(target = '', packages) {
         }
 
         default: {
-            return packages.map(pkgJsonPath => {
+            return packages.map((pkgJsonPath) => {
                 return [
                     '@semantic-release/npm',
                     {
@@ -72,15 +72,15 @@ const handler = async ({ publish }) => {
         {
             assets: [
                 'CHANGELOG.md',
-                packages.map(pkgJsonPath =>
+                packages.map((pkgJsonPath) =>
                     path.relative(process.cwd(), pkgJsonPath)
                 ),
                 packages
-                    .map(pkgJsonPath =>
+                    .map((pkgJsonPath) =>
                         path.join(path.dirname(pkgJsonPath), 'yarn.lock')
                     )
                     .filter(existsSync)
-                    .map(pkgJsonPath =>
+                    .map((pkgJsonPath) =>
                         path.relative(process.cwd(), pkgJsonPath)
                     ),
             ],
@@ -109,7 +109,7 @@ const handler = async ({ publish }) => {
      * https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md
      */
     const options = {
-        plugins: plugins.filter(n => !!n),
+        plugins: plugins.filter((n) => !!n),
     }
 
     const config = {

--- a/packages/utils/src/cmds/schema.js
+++ b/packages/utils/src/cmds/schema.js
@@ -2,7 +2,7 @@ const { namespace } = require('@dhis2/cli-helpers-engine')
 
 const command = namespace('schema', {
     desc: 'Utils for schema operations',
-    builder: yargs =>
+    builder: (yargs) =>
         yargs
             .option('force', {
                 type: 'boolean',

--- a/packages/utils/src/cmds/schema/diff/index.js
+++ b/packages/utils/src/cmds/schema/diff/index.js
@@ -16,11 +16,11 @@ const DHIS2HtmlFormatter = require('./schemaHtmlFormatter')
 let cache
 // We use the singular property as an unique identifier for schemas
 // name and type are used for other nested properties
-const objectHash = obj =>
+const objectHash = (obj) =>
     obj.singular || obj.name || obj.fieldName || obj.type || obj
 const Differ = jsondiffpatch.create({
     objectHash,
-    propertyFilter: name => name !== 'href' && name !== 'apiEndpoint',
+    propertyFilter: (name) => name !== 'href' && name !== 'apiEndpoint',
     arrays: {
         detectMove: true,
         includeValueOnMove: true,
@@ -69,7 +69,7 @@ function sortSchemaObject(a, b) {
 }
 
 function sortArrayProps(obj) {
-    Object.keys(obj).forEach(key => {
+    Object.keys(obj).forEach((key) => {
         const val = obj[key]
         if (Array.isArray(val)) {
             const sorted = val.sort(sortSchemaObject)
@@ -206,7 +206,7 @@ async function run(args) {
     })
 }
 
-const builder = yargs => {
+const builder = (yargs) => {
     yargs
         .positional('leftUrl', {
             type: 'string',
@@ -220,7 +220,7 @@ const builder = yargs => {
         })
         .option('base-url', {
             alias: 'b',
-            coerce: opt => utils.prependHttpsProtocol(opt),
+            coerce: (opt) => utils.prependHttpsProtocol(opt),
             describe: `BaseUrl to use for downloading schemas. If this is set leftServer and rightServer should be relative to this url, eg. /dev.`,
             type: 'string',
         })

--- a/packages/utils/src/cmds/schema/diff/index.js
+++ b/packages/utils/src/cmds/schema/diff/index.js
@@ -3,15 +3,15 @@ const path = require('path')
 const { reporter } = require('@dhis2/cli-helpers-engine')
 const ejs = require('ejs')
 const jsondiffpatch = require('jsondiffpatch')
+const utils = require('../../../support/utils.js')
 const {
     schemasFromUrl,
     writeOutput,
     schemaDiffIdentifier,
     defaultOpts,
     resolveConfig,
-} = require('../')
-const utils = require('../../../support/utils')
-const DHIS2HtmlFormatter = require('./schemaHtmlFormatter')
+} = require('../index.js')
+const DHIS2HtmlFormatter = require('./schemaHtmlFormatter.js')
 
 let cache
 // We use the singular property as an unique identifier for schemas
@@ -63,8 +63,12 @@ async function getSchemas(urlLike, { baseUrl, auth, force }) {
 function sortSchemaObject(a, b) {
     const aHash = objectHash(a)
     const bHash = objectHash(b)
-    if (aHash < bHash) return -1
-    if (aHash > bHash) return 1
+    if (aHash < bHash) {
+        return -1
+    }
+    if (aHash > bHash) {
+        return 1
+    }
     return 0
 }
 

--- a/packages/utils/src/cmds/schema/fetch.js
+++ b/packages/utils/src/cmds/schema/fetch.js
@@ -1,6 +1,9 @@
 const path = require('path')
 const { reporter } = require('@dhis2/cli-helpers-engine')
-const { prependHttpsProtocol, isRelativeUrl } = require('../../support/utils')
+const {
+    prependHttpsProtocol,
+    isRelativeUrl,
+} = require('../../support/utils.js')
 const {
     schemasFromUrl,
     writeOutput,

--- a/packages/utils/src/cmds/schema/fetch.js
+++ b/packages/utils/src/cmds/schema/fetch.js
@@ -55,7 +55,7 @@ const command = {
         },
         'base-url': {
             alias: 'b',
-            coerce: opt => prependHttpsProtocol(opt),
+            coerce: (opt) => prependHttpsProtocol(opt),
             describe: `BaseUrl to use for downloading schemas. If this is set, urls that are relative (starts with /) will be appended to this url. eg. /dev.`,
             type: 'string',
         },

--- a/packages/utils/src/cmds/schema/index.js
+++ b/packages/utils/src/cmds/schema/index.js
@@ -3,7 +3,7 @@ const path = require('path')
 const { reporter } = require('@dhis2/cli-helpers-engine')
 const inquirer = require('inquirer')
 const request = require('request')
-const utils = require('../../support/utils')
+const utils = require('../../support/utils.js')
 
 const defaultOpts = {
     schemasEndpoint: '/api/schemas.json',
@@ -61,7 +61,9 @@ function authFromConf(conf = {}, serverConfig = {}) {
         username: serverConfig.username || conf.username,
         password: serverConfig.password || conf.password,
     }
-    if (auth.username && auth.password) return auth
+    if (auth.username && auth.password) {
+        return auth
+    }
     return true
 }
 

--- a/packages/utils/src/cmds/schema/index.js
+++ b/packages/utils/src/cmds/schema/index.js
@@ -19,12 +19,12 @@ const defaultRequestOpts = {
 
 const prompt = inquirer.createPromptModule({ output: process.stderr })
 
-const schemaIdentifier = info => `${info.version}_${info.revision}`
+const schemaIdentifier = (info) => `${info.version}_${info.revision}`
 const schemaDiffIdentifier = (info1, info2) =>
     `${schemaIdentifier(info1)}__${schemaIdentifier(info2)}`
 
 function asyncRequest(url, opts) {
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
         request.get(url, opts, (err, res, body) => {
             if (err || res.statusCode > 299) {
                 reporter.error('Request', url, 'failed to fetch')

--- a/packages/utils/src/cmds/uid.js
+++ b/packages/utils/src/cmds/uid.js
@@ -17,7 +17,7 @@ const generateCmd = {
             type: 'boolean',
         },
     },
-    handler: argv => {
+    handler: (argv) => {
         const { limit } = argv
 
         const codes = generateCodes(limit || 10)
@@ -44,7 +44,7 @@ const generateCmd = {
 module.exports = namespace('uid', {
     desc: 'DHIS2 UID tools',
     aliases: 'u',
-    builder: yargs => {
+    builder: (yargs) => {
         return yargs.command(generateCmd)
     },
 })

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -2,7 +2,7 @@ const { namespace, createModuleLoader } = require('@dhis2/cli-helpers-engine')
 
 const command = namespace('utils', {
     desc: 'Utils for miscellaneous operations',
-    builder: yargs => {
+    builder: (yargs) => {
         const loader = createModuleLoader({
             parentModule: __filename,
         })

--- a/packages/utils/src/support/getWorkspacePackages.js
+++ b/packages/utils/src/support/getWorkspacePackages.js
@@ -3,14 +3,14 @@ const { reporter } = require('@dhis2/cli-helpers-engine')
 const glob = require('glob')
 
 // Simplified from https://github.com/yarnpkg/yarn/blob/bb9741af4d1fe00adb15e4a7596c7a3472d0bda3/src/config.js#L814
-const globPackageFilePattern = pattern =>
+const globPackageFilePattern = (pattern) =>
     glob.sync(
         path.join(process.cwd(), pattern.replace(/\/?$/, '/package.json')),
         {
             ignore: pattern.replace(/\/?$/, '/node_modules/**/package.json'),
         }
     )
-const getWorkspacePackages = async packageFile => {
+const getWorkspacePackages = async (packageFile) => {
     try {
         const rootPackage = require(packageFile)
         if (rootPackage.workspaces) {

--- a/packages/utils/src/support/normalizeAndValidatePackages.js
+++ b/packages/utils/src/support/normalizeAndValidatePackages.js
@@ -1,11 +1,11 @@
 const fs = require('fs')
 const path = require('path')
 
-const normalizeAndValidatePackages = packages => {
+const normalizeAndValidatePackages = (packages) => {
     const errors = []
     const validPackages = []
 
-    packages.forEach(packagePath => {
+    packages.forEach((packagePath) => {
         let pkgJsonPath
         if (!fs.existsSync(packagePath)) {
             errors.push(`Path ${packagePath} does not exist`)

--- a/packages/utils/src/support/semantic-release-update-deps.js
+++ b/packages/utils/src/support/semantic-release-update-deps.js
@@ -21,7 +21,7 @@ const verifyConditions = (config = {}, context) => {
         throw new AggregateError(errors)
     }
 
-    validPackages.forEach(pkg => {
+    validPackages.forEach((pkg) => {
         pkg.label = pkg.json.name || '<unnamed>'
         if (!silent) {
             logger.log(`Package ${pkg.label} found at ${pkg.path}`)
@@ -33,8 +33,8 @@ const verifyConditions = (config = {}, context) => {
 
 const replaceDependencies = ({ pkg, listNames, packageNames, version }) => {
     const dependencies = []
-    packageNames.forEach(packageName => {
-        listNames.forEach(listName => {
+    packageNames.forEach((packageName) => {
+        listNames.forEach((listName) => {
             if (pkg[listName] && pkg[listName][packageName]) {
                 pkg[listName][packageName] = version
                 dependencies.push(`${packageName} (${listName})`)
@@ -55,8 +55,8 @@ const prepare = (config, context) => {
         ? nextRelease.version
         : `^${nextRelease.version}`
 
-    const names = packages.map(pkg => pkg.json.name).filter(n => n)
-    packages.forEach(pkg => {
+    const names = packages.map((pkg) => pkg.json.name).filter((n) => n)
+    packages.forEach((pkg) => {
         const pkgJson = pkg.json
         const relativePath = path.relative(context.cwd, pkg.path)
 
@@ -75,7 +75,7 @@ const prepare = (config, context) => {
             packageNames: names,
             version: targetVersion,
         }).forEach(
-            dep =>
+            (dep) =>
                 !silent &&
                 logger.log(
                     `Upgraded dependency ${dep}@${targetVersion} for ${pkg.label} at ${relativePath}`

--- a/packages/utils/src/support/semantic-release-update-deps.js
+++ b/packages/utils/src/support/semantic-release-update-deps.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const path = require('path')
 const SemanticReleaseError = require('@semantic-release/error')
 const AggregateError = require('aggregate-error')
-const normalizeAndValidatePackages = require('./normalizeAndValidatePackages')
+const normalizeAndValidatePackages = require('./normalizeAndValidatePackages.js')
 
 const verifyConditions = (config = {}, context) => {
     const { silent, packages } = config

--- a/yarn.lock
+++ b/yarn.lock
@@ -1281,10 +1281,32 @@
     resolve-global "1.0.0"
     yargs "^15.1.0"
 
+"@commitlint/cli@^12.1.4":
+  version "12.1.4"
+  resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-12.1.4.tgz#af4d9dd3c0122c7b39a61fa1cd2abbad0422dbe0"
+  integrity sha512-ZR1WjXLvqEffYyBPT0XdnSxtt3Ty1TMoujEtseW5o3vPnkA1UNashAMjQVg/oELqfaiAMnDw8SERPMN0e/0kLg==
+  dependencies:
+    "@commitlint/format" "^12.1.4"
+    "@commitlint/lint" "^12.1.4"
+    "@commitlint/load" "^12.1.4"
+    "@commitlint/read" "^12.1.4"
+    "@commitlint/types" "^12.1.4"
+    lodash "^4.17.19"
+    resolve-from "5.0.0"
+    resolve-global "1.0.0"
+    yargs "^16.2.0"
+
 "@commitlint/config-conventional@^11.0.0":
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/@commitlint/config-conventional/-/config-conventional-11.0.0.tgz#3fa300a1b639273946de3c3f15e1cda518333422"
   integrity sha512-SNDRsb5gLuDd2PL83yCOQX6pE7gevC79UPFx+GLbLfw6jGnnbO9/tlL76MLD8MOViqGbo7ZicjChO9Gn+7tHhA==
+  dependencies:
+    conventional-changelog-conventionalcommits "^4.3.1"
+
+"@commitlint/config-conventional@^13.1.0":
+  version "13.2.0"
+  resolved "https://registry.yarnpkg.com/@commitlint/config-conventional/-/config-conventional-13.2.0.tgz#2ad24fecc56ae9619dbe0934b98a98b18ace0bec"
+  integrity sha512-7u7DdOiF+3qSdDlbQGfpvCH8DCQdLFvnI2+VucYmmV7E92iD6t9PBj+UjIoSQCaMAzYp27Vkall78AkcXBh6Xw==
   dependencies:
     conventional-changelog-conventionalcommits "^4.3.1"
 
@@ -1296,10 +1318,23 @@
     "@commitlint/types" "^11.0.0"
     lodash "^4.17.19"
 
+"@commitlint/ensure@^12.1.4":
+  version "12.1.4"
+  resolved "https://registry.yarnpkg.com/@commitlint/ensure/-/ensure-12.1.4.tgz#287ae2dcc5ccb086e749705b1bd9bdb99773056f"
+  integrity sha512-MxHIBuAG9M4xl33qUfIeMSasbv3ktK0W+iygldBxZOL4QSYC2Gn66pZAQMnV9o3V+sVFHoAK2XUKqBAYrgbEqw==
+  dependencies:
+    "@commitlint/types" "^12.1.4"
+    lodash "^4.17.19"
+
 "@commitlint/execute-rule@^11.0.0":
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/@commitlint/execute-rule/-/execute-rule-11.0.0.tgz#3ed60ab7a33019e58d90e2d891b75d7df77b4b4d"
   integrity sha512-g01p1g4BmYlZ2+tdotCavrMunnPFPhTzG1ZiLKTCYrooHRbmvqo42ZZn4QMStUEIcn+jfLb6BRZX3JzIwA1ezQ==
+
+"@commitlint/execute-rule@^12.1.4":
+  version "12.1.4"
+  resolved "https://registry.yarnpkg.com/@commitlint/execute-rule/-/execute-rule-12.1.4.tgz#9973b02e9779adbf1522ae9ac207a4815ec73de1"
+  integrity sha512-h2S1j8SXyNeABb27q2Ok2vD1WfxJiXvOttKuRA9Or7LN6OQoC/KtT3844CIhhWNteNMu/wE0gkTqGxDVAnJiHg==
 
 "@commitlint/format@^11.0.0":
   version "11.0.0"
@@ -1307,6 +1342,14 @@
   integrity sha512-bpBLWmG0wfZH/svzqD1hsGTpm79TKJWcf6EXZllh2J/LSSYKxGlv967lpw0hNojme0sZd4a/97R3qA2QHWWSLg==
   dependencies:
     "@commitlint/types" "^11.0.0"
+    chalk "^4.0.0"
+
+"@commitlint/format@^12.1.4":
+  version "12.1.4"
+  resolved "https://registry.yarnpkg.com/@commitlint/format/-/format-12.1.4.tgz#db2d46418a6ae57c90e5f7f65dff46f0265d9f24"
+  integrity sha512-h28ucMaoRjVvvgS6Bdf85fa/+ZZ/iu1aeWGCpURnQV7/rrVjkhNSjZwGlCOUd5kDV1EnZ5XdI7L18SUpRjs26g==
+  dependencies:
+    "@commitlint/types" "^12.1.4"
     chalk "^4.0.0"
 
 "@commitlint/is-ignored@^11.0.0":
@@ -1317,6 +1360,14 @@
     "@commitlint/types" "^11.0.0"
     semver "7.3.2"
 
+"@commitlint/is-ignored@^12.1.4":
+  version "12.1.4"
+  resolved "https://registry.yarnpkg.com/@commitlint/is-ignored/-/is-ignored-12.1.4.tgz#4c430bc3b361aa9be5cd4ddb252c1559870ea7bc"
+  integrity sha512-uTu2jQU2SKvtIRVLOzMQo3KxDtO+iJ1p0olmncwrqy4AfPLgwoyCP2CiULq5M7xpR3+dE3hBlZXbZTQbD7ycIw==
+  dependencies:
+    "@commitlint/types" "^12.1.4"
+    semver "7.3.5"
+
 "@commitlint/lint@^11.0.0":
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/@commitlint/lint/-/lint-11.0.0.tgz#01e062cd1b0e7c3d756aa2c246462e0b6a3348a4"
@@ -1326,6 +1377,16 @@
     "@commitlint/parse" "^11.0.0"
     "@commitlint/rules" "^11.0.0"
     "@commitlint/types" "^11.0.0"
+
+"@commitlint/lint@^12.1.4":
+  version "12.1.4"
+  resolved "https://registry.yarnpkg.com/@commitlint/lint/-/lint-12.1.4.tgz#856b7fd2b2e6367b836cb84a12f1c1b3c0e40d22"
+  integrity sha512-1kZ8YDp4to47oIPFELUFGLiLumtPNKJigPFDuHt2+f3Q3IKdQ0uk53n3CPl4uoyso/Og/EZvb1mXjFR/Yce4cA==
+  dependencies:
+    "@commitlint/is-ignored" "^12.1.4"
+    "@commitlint/parse" "^12.1.4"
+    "@commitlint/rules" "^12.1.4"
+    "@commitlint/types" "^12.1.4"
 
 "@commitlint/load@^11.0.0":
   version "11.0.0"
@@ -1340,10 +1401,28 @@
     lodash "^4.17.19"
     resolve-from "^5.0.0"
 
+"@commitlint/load@^12.1.4":
+  version "12.1.4"
+  resolved "https://registry.yarnpkg.com/@commitlint/load/-/load-12.1.4.tgz#e3c2dbc0e7d8d928f57a6878bd7219909fc0acab"
+  integrity sha512-Keszi0IOjRzKfxT+qES/n+KZyLrxy79RQz8wWgssCboYjKEp+wC+fLCgbiMCYjI5k31CIzIOq/16J7Ycr0C0EA==
+  dependencies:
+    "@commitlint/execute-rule" "^12.1.4"
+    "@commitlint/resolve-extends" "^12.1.4"
+    "@commitlint/types" "^12.1.4"
+    chalk "^4.0.0"
+    cosmiconfig "^7.0.0"
+    lodash "^4.17.19"
+    resolve-from "^5.0.0"
+
 "@commitlint/message@^11.0.0":
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/@commitlint/message/-/message-11.0.0.tgz#83554c3cbbc884fd07b473593bc3e94bcaa3ee05"
   integrity sha512-01ObK/18JL7PEIE3dBRtoMmU6S3ecPYDTQWWhcO+ErA3Ai0KDYqV5VWWEijdcVafNpdeUNrEMigRkxXHQLbyJA==
+
+"@commitlint/message@^12.1.4":
+  version "12.1.4"
+  resolved "https://registry.yarnpkg.com/@commitlint/message/-/message-12.1.4.tgz#3895edcc0709deca5945f3d55f5ea95a9f1f446d"
+  integrity sha512-6QhalEKsKQ/Y16/cTk5NH4iByz26fqws2ub+AinHPtM7Io0jy4e3rym9iE+TkEqiqWZlUigZnTwbPvRJeSUBaA==
 
 "@commitlint/parse@^11.0.0":
   version "11.0.0"
@@ -1351,6 +1430,15 @@
   integrity sha512-DekKQAIYWAXIcyAZ6/PDBJylWJ1BROTfDIzr9PMVxZRxBPc1gW2TG8fLgjZfBP5mc0cuthPkVi91KQQKGri/7A==
   dependencies:
     conventional-changelog-angular "^5.0.0"
+    conventional-commits-parser "^3.0.0"
+
+"@commitlint/parse@^12.1.4":
+  version "12.1.4"
+  resolved "https://registry.yarnpkg.com/@commitlint/parse/-/parse-12.1.4.tgz#ba03d54d24ef84f6fd2ff31c5e9998b22d7d0aa1"
+  integrity sha512-yqKSAsK2V4X/HaLb/yYdrzs6oD/G48Ilt0EJ2Mp6RJeWYxG14w/Out6JrneWnr/cpzemyN5hExOg6+TB19H/Lw==
+  dependencies:
+    "@commitlint/types" "^12.1.4"
+    conventional-changelog-angular "^5.0.11"
     conventional-commits-parser "^3.0.0"
 
 "@commitlint/read@^11.0.0":
@@ -1362,10 +1450,30 @@
     fs-extra "^9.0.0"
     git-raw-commits "^2.0.0"
 
+"@commitlint/read@^12.1.4":
+  version "12.1.4"
+  resolved "https://registry.yarnpkg.com/@commitlint/read/-/read-12.1.4.tgz#552fda42ef185d5b578beb6f626a5f8b282de3a6"
+  integrity sha512-TnPQSJgD8Aod5Xeo9W4SaYKRZmIahukjcCWJ2s5zb3ZYSmj6C85YD9cR5vlRyrZjj78ItLUV/X4FMWWVIS38Jg==
+  dependencies:
+    "@commitlint/top-level" "^12.1.4"
+    "@commitlint/types" "^12.1.4"
+    fs-extra "^9.0.0"
+    git-raw-commits "^2.0.0"
+
 "@commitlint/resolve-extends@^11.0.0":
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/@commitlint/resolve-extends/-/resolve-extends-11.0.0.tgz#158ecbe27d4a2a51d426111a01478e216fbb1036"
   integrity sha512-WinU6Uv6L7HDGLqn/To13KM1CWvZ09VHZqryqxXa1OY+EvJkfU734CwnOEeNlSCK7FVLrB4kmodLJtL1dkEpXw==
+  dependencies:
+    import-fresh "^3.0.0"
+    lodash "^4.17.19"
+    resolve-from "^5.0.0"
+    resolve-global "^1.0.0"
+
+"@commitlint/resolve-extends@^12.1.4":
+  version "12.1.4"
+  resolved "https://registry.yarnpkg.com/@commitlint/resolve-extends/-/resolve-extends-12.1.4.tgz#e758ed7dcdf942618b9f603a7c28a640f6a0802a"
+  integrity sha512-R9CoUtsXLd6KSCfsZly04grsH6JVnWFmVtWgWs1KdDpdV+G3TSs37tColMFqglpkx3dsWu8dsPD56+D9YnJfqg==
   dependencies:
     import-fresh "^3.0.0"
     lodash "^4.17.19"
@@ -1382,10 +1490,25 @@
     "@commitlint/to-lines" "^11.0.0"
     "@commitlint/types" "^11.0.0"
 
+"@commitlint/rules@^12.1.4":
+  version "12.1.4"
+  resolved "https://registry.yarnpkg.com/@commitlint/rules/-/rules-12.1.4.tgz#0e141b08caa3d7bdc48aa784baa8baff3efd64db"
+  integrity sha512-W8m6ZSjg7RuIsIfzQiFHa48X5mcPXeKT9yjBxVmjHvYfS2FDBf1VxCQ7vO0JTVIdV4ohjZ0eKg/wxxUuZHJAZg==
+  dependencies:
+    "@commitlint/ensure" "^12.1.4"
+    "@commitlint/message" "^12.1.4"
+    "@commitlint/to-lines" "^12.1.4"
+    "@commitlint/types" "^12.1.4"
+
 "@commitlint/to-lines@^11.0.0":
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/@commitlint/to-lines/-/to-lines-11.0.0.tgz#86dea151c10eea41e39ea96fa4de07839258a7fe"
   integrity sha512-TIDTB0Y23jlCNubDROUVokbJk6860idYB5cZkLWcRS9tlb6YSoeLn1NLafPlrhhkkkZzTYnlKYzCVrBNVes1iw==
+
+"@commitlint/to-lines@^12.1.4":
+  version "12.1.4"
+  resolved "https://registry.yarnpkg.com/@commitlint/to-lines/-/to-lines-12.1.4.tgz#caa582dbf121f377a0588bb64e25c4854843cd25"
+  integrity sha512-TParumvbi8bdx3EdLXz2MaX+e15ZgoCqNUgqHsRLwyqLUTRbqCVkzrfadG1UcMQk8/d5aMbb327ZKG3Q4BRorw==
 
 "@commitlint/top-level@^11.0.0":
   version "11.0.0"
@@ -1394,10 +1517,24 @@
   dependencies:
     find-up "^5.0.0"
 
+"@commitlint/top-level@^12.1.4":
+  version "12.1.4"
+  resolved "https://registry.yarnpkg.com/@commitlint/top-level/-/top-level-12.1.4.tgz#96d5c715bfc1bdf86dfcf11b67fc2cf7658c7a6e"
+  integrity sha512-d4lTJrOT/dXlpY+NIt4CUl77ciEzYeNVc0VFgUQ6VA+b1rqYD2/VWFjBlWVOrklxtSDeKyuEhs36RGrppEFAvg==
+  dependencies:
+    find-up "^5.0.0"
+
 "@commitlint/types@^11.0.0":
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/@commitlint/types/-/types-11.0.0.tgz#719cf05fcc1abb6533610a2e0f5dd1e61eac14fe"
   integrity sha512-VoNqai1vR5anRF5Tuh/+SWDFk7xi7oMwHrHrbm1BprYXjB2RJsWLhUrStMssDxEl5lW/z3EUdg8RvH/IUBccSQ==
+
+"@commitlint/types@^12.1.4":
+  version "12.1.4"
+  resolved "https://registry.yarnpkg.com/@commitlint/types/-/types-12.1.4.tgz#9618a5dc8991fb58e6de6ed89d7bf712fa74ba7e"
+  integrity sha512-KRIjdnWNUx6ywz+SJvjmNCbQKcKP6KArhjZhY2l+CWKxak0d77SOjggkMwFTiSgLODOwmuLTbarR2ZfWPiPMlw==
+  dependencies:
+    chalk "^4.0.0"
 
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"
@@ -2070,6 +2207,30 @@
     handlebars "^4.7.3"
     isbinaryfile "^4.0.4"
 
+"@dhis2/cli-style@^10.5.1":
+  version "10.5.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/cli-style/-/cli-style-10.5.1.tgz#cf2df63b5eb203e3e3cec867bb9ba53b0d6f2ed6"
+  integrity sha512-epMQFxX+A7HzivXMqX5pHSJqP/CRw94HHWOZ+ab8Ug930Y3gF8YG1QtXgfvdMFz7u+LfQlLujj+DgVa/6W5GTQ==
+  dependencies:
+    "@commitlint/cli" "^12.1.4"
+    "@commitlint/config-conventional" "^13.1.0"
+    "@dhis2/cli-helpers-engine" "^3.0.0"
+    "@ls-lint/ls-lint" "^1.10.0"
+    babel-eslint "^10.1.0"
+    eslint "^7.32.0"
+    eslint-config-prettier "^8.3.0"
+    eslint-plugin-import "^2.22.1"
+    eslint-plugin-react "^7.31.10"
+    fast-glob "^3.2.5"
+    find-up "^5.0.0"
+    fs-extra "^10.0.0"
+    husky "^7.0.2"
+    micromatch "^4.0.4"
+    perfy "^1.1.5"
+    prettier "^2.4.1"
+    semver "^7.3.5"
+    yargs "^16.2.0"
+
 "@dhis2/cli-style@^9.0.1":
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/@dhis2/cli-style/-/cli-style-9.0.1.tgz#919bb978362ed9aeb7a253a3b58d6f25e3c09bd9"
@@ -2116,6 +2277,26 @@
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@dhis2/cli-utils-docsite/-/cli-utils-docsite-3.1.2.tgz#ee67683b1611ae684cd6ab2f29a61b5fd1f2d31a"
   integrity sha512-0gyXG8fcVt5qtvGlDaGY+q4F3He0Z8lD2nI4uVNkNJY0IMOCVIodeQT1WN8OZOl/R0tTGKTQui0T1XueyFsiLg==
+  dependencies:
+    "@dhis2/cli-helpers-engine" "^3.0.0"
+    "@dhis2/cli-helpers-template" "^3.0.0"
+    ast-types "^0.14.2"
+    chokidar "^3.3.1"
+    front-matter "^3.1.0"
+    fs-extra "^8.1.0"
+    glob "^7.1.7"
+    hyperscript-html "^2.0.0"
+    jsdoc-to-markdown "^5.0.3"
+    live-server "^1.2.1"
+    marked "^2.1.3"
+    match-all "^1.2.5"
+    react-docgen "^6.0.0-alpha.0"
+    url-join "^4.0.1"
+
+"@dhis2/cli-utils-docsite@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/cli-utils-docsite/-/cli-utils-docsite-3.2.0.tgz#a9234bd71d1b716dfdba54e711bbc0ff8e102dd1"
+  integrity sha512-U7gUb7PSHdCkWlzMznUQCQR2Lkp+/pMwoo8DC01OzL8JjFojZtP+iSY4Zx4JCmQz7s1Ncyy1bmwRx1+ogQCSsQ==
   dependencies:
     "@dhis2/cli-helpers-engine" "^3.0.0"
     "@dhis2/cli-helpers-template" "^3.0.0"
@@ -2243,6 +2424,21 @@
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.2.tgz#f63d0ef06f5c0c57d76c4ab5f63d3835c51b0179"
   integrity sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==
+  dependencies:
+    ajv "^6.12.4"
+    debug "^4.1.1"
+    espree "^7.3.0"
+    globals "^13.9.0"
+    ignore "^4.0.6"
+    import-fresh "^3.2.1"
+    js-yaml "^3.13.1"
+    minimatch "^3.0.4"
+    strip-json-comments "^3.1.1"
+
+"@eslint/eslintrc@^0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.3.tgz#9e42981ef035beb3dd49add17acb96e8ff6f394c"
+  integrity sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==
   dependencies:
     ajv "^6.12.4"
     debug "^4.1.1"
@@ -2656,10 +2852,10 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@ls-lint/ls-lint@^1.9.2":
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/@ls-lint/ls-lint/-/ls-lint-1.9.2.tgz#689f1f4c06072823a726802ba167340efcefe19c"
-  integrity sha512-sugEjWjSSy9OHF6t1ZBLZCAROj52cZthB9dIePmzZzzMwmWwy3qAEMSdJheHeS1FOwDZI7Ipm1H/bWgzJNnSAw==
+"@ls-lint/ls-lint@2.0.1", "@ls-lint/ls-lint@^1.10.0", "@ls-lint/ls-lint@^1.9.2":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@ls-lint/ls-lint/-/ls-lint-2.0.1.tgz#27a0513fde8e06704ff174b0a696d473190b8874"
+  integrity sha512-z+sGTPWHQ2nWRj2UsDFSEQDOCw2iIjP2bPU/K1wgLNkWUv7J8WjzoBsZLgUqIgD1Sqi7zpksFTtTymgnUwramA==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -4302,6 +4498,14 @@ array-back@^4.0.0, array-back@^4.0.1:
   resolved "https://registry.yarnpkg.com/array-back/-/array-back-4.0.2.tgz#8004e999a6274586beeb27342168652fdb89fa1e"
   integrity sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==
 
+array-buffer-byte-length@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz#fabe8bc193fea865f317fe7807085ee0dee5aead"
+  integrity sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==
+  dependencies:
+    call-bind "^1.0.2"
+    is-array-buffer "^3.0.1"
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
@@ -4327,6 +4531,17 @@ array-includes@^3.1.1, array-includes@^3.1.2, array-includes@^3.1.3:
     es-abstract "^1.18.0-next.2"
     get-intrinsic "^1.1.1"
     is-string "^1.0.5"
+
+array-includes@^3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.6.tgz#9e9e720e194f198266ba9e18c29e6a9b0e4b225f"
+  integrity sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+    get-intrinsic "^1.1.3"
+    is-string "^1.0.7"
 
 array-union@^1.0.1:
   version "1.0.2"
@@ -4368,6 +4583,39 @@ array.prototype.flatmap@^1.2.4:
     define-properties "^1.1.3"
     es-abstract "^1.18.0-next.1"
     function-bind "^1.1.1"
+
+array.prototype.flatmap@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz#1aae7903c2100433cb8261cd4ed310aab5c4a183"
+  integrity sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+    es-shim-unscopables "^1.0.0"
+
+array.prototype.tosorted@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz#ccf44738aa2b5ac56578ffda97c03fd3e23dd532"
+  integrity sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+    es-shim-unscopables "^1.0.0"
+    get-intrinsic "^1.1.3"
+
+arraybuffer.prototype.slice@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.1.tgz#9b5ea3868a6eebc30273da577eb888381c0044bb"
+  integrity sha512-09x0ZWFEjj4WD8PDbykUwo3t9arLn8NIzmmYEJFpYekOAQjpkGSyrQhNoRTcwwcFRu+ycWF78QZ63oWTqSjBcw==
+  dependencies:
+    array-buffer-byte-length "^1.0.0"
+    call-bind "^1.0.2"
+    define-properties "^1.2.0"
+    get-intrinsic "^1.2.1"
+    is-array-buffer "^3.0.2"
+    is-shared-array-buffer "^1.0.2"
 
 arrify@^1.0.1:
   version "1.0.1"
@@ -4458,6 +4706,13 @@ async@^2.6.2, async@^2.6.3:
   dependencies:
     lodash "^4.17.14"
 
+asynciterator.prototype@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/asynciterator.prototype/-/asynciterator.prototype-1.0.0.tgz#8c5df0514936cdd133604dfcc9d3fb93f09b2b62"
+  integrity sha512-wwHYEIS0Q80f5mosx3L/dfG5t5rjEa9Ft51GTaNt862EnpyGHpgz2RkZvLPp1oF5TnAiTohkEKVEu8pQPJI7Vg==
+  dependencies:
+    has-symbols "^1.0.3"
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -4490,6 +4745,11 @@ autoprefixer@^9.6.1:
     num2fraction "^1.2.2"
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
+
+available-typed-arrays@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
+  integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -5951,6 +6211,14 @@ conventional-changelog-angular@^5.0.0:
     compare-func "^2.0.0"
     q "^1.5.1"
 
+conventional-changelog-angular@^5.0.11:
+  version "5.0.13"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz#896885d63b914a70d4934b59d2fe7bde1832b28c"
+  integrity sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==
+  dependencies:
+    compare-func "^2.0.0"
+    q "^1.5.1"
+
 conventional-changelog-conventionalcommits@^4.3.1:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.0.tgz#7fc17211dbca160acf24687bd2fdd5fd767750eb"
@@ -6594,6 +6862,14 @@ define-properties@^1.1.2, define-properties@^1.1.3:
   dependencies:
     object-keys "^1.0.12"
 
+define-properties@^1.1.4, define-properties@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.2.0.tgz#52988570670c9eacedd8064f4a990f2405849bd5"
+  integrity sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==
+  dependencies:
+    has-property-descriptors "^1.0.0"
+    object-keys "^1.1.1"
+
 define-property@^0.2.5:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
@@ -7174,10 +7450,91 @@ es-abstract@^1.17.2, es-abstract@^1.18.0-next.1, es-abstract@^1.18.0-next.2, es-
     string.prototype.trimstart "^1.0.4"
     unbox-primitive "^1.0.1"
 
+es-abstract@^1.19.0, es-abstract@^1.20.4, es-abstract@^1.21.3:
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.22.1.tgz#8b4e5fc5cefd7f1660f0f8e1a52900dfbc9d9ccc"
+  integrity sha512-ioRRcXMO6OFyRpyzV3kE1IIBd4WG5/kltnzdxSCqoP8CMGs/Li+M1uF5o7lOkZVFjDs+NLesthnF66Pg/0q0Lw==
+  dependencies:
+    array-buffer-byte-length "^1.0.0"
+    arraybuffer.prototype.slice "^1.0.1"
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    es-set-tostringtag "^2.0.1"
+    es-to-primitive "^1.2.1"
+    function.prototype.name "^1.1.5"
+    get-intrinsic "^1.2.1"
+    get-symbol-description "^1.0.0"
+    globalthis "^1.0.3"
+    gopd "^1.0.1"
+    has "^1.0.3"
+    has-property-descriptors "^1.0.0"
+    has-proto "^1.0.1"
+    has-symbols "^1.0.3"
+    internal-slot "^1.0.5"
+    is-array-buffer "^3.0.2"
+    is-callable "^1.2.7"
+    is-negative-zero "^2.0.2"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.2"
+    is-string "^1.0.7"
+    is-typed-array "^1.1.10"
+    is-weakref "^1.0.2"
+    object-inspect "^1.12.3"
+    object-keys "^1.1.1"
+    object.assign "^4.1.4"
+    regexp.prototype.flags "^1.5.0"
+    safe-array-concat "^1.0.0"
+    safe-regex-test "^1.0.0"
+    string.prototype.trim "^1.2.7"
+    string.prototype.trimend "^1.0.6"
+    string.prototype.trimstart "^1.0.6"
+    typed-array-buffer "^1.0.0"
+    typed-array-byte-length "^1.0.0"
+    typed-array-byte-offset "^1.0.0"
+    typed-array-length "^1.0.4"
+    unbox-primitive "^1.0.2"
+    which-typed-array "^1.1.10"
+
+es-iterator-helpers@^1.0.12:
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/es-iterator-helpers/-/es-iterator-helpers-1.0.13.tgz#72101046ffc19baf9996adc70e6177a26e6e8084"
+  integrity sha512-LK3VGwzvaPWobO8xzXXGRUOGw8Dcjyfk62CsY/wfHN75CwsJPbuypOYJxK6g5RyEL8YDjIWcl6jgd8foO6mmrA==
+  dependencies:
+    asynciterator.prototype "^1.0.0"
+    call-bind "^1.0.2"
+    define-properties "^1.2.0"
+    es-abstract "^1.21.3"
+    es-set-tostringtag "^2.0.1"
+    function-bind "^1.1.1"
+    get-intrinsic "^1.2.1"
+    globalthis "^1.0.3"
+    has-property-descriptors "^1.0.0"
+    has-proto "^1.0.1"
+    has-symbols "^1.0.3"
+    internal-slot "^1.0.5"
+    iterator.prototype "^1.1.0"
+    safe-array-concat "^1.0.0"
+
 es-module-lexer@^0.9.0:
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.9.3.tgz#6f13db00cc38417137daf74366f535c8eb438f19"
   integrity sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==
+
+es-set-tostringtag@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz#338d502f6f674301d710b80c8592de8a15f09cd8"
+  integrity sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==
+  dependencies:
+    get-intrinsic "^1.1.3"
+    has "^1.0.3"
+    has-tostringtag "^1.0.0"
+
+es-shim-unscopables@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz#702e632193201e3edf8713635d083d378e510241"
+  integrity sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==
+  dependencies:
+    has "^1.0.3"
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -7255,6 +7612,11 @@ eslint-config-prettier@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz#f4a4bd2832e810e8cc7c1411ec85b3e85c0c53f9"
   integrity sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==
+
+eslint-config-prettier@^8.3.0:
+  version "8.10.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz#3a06a662130807e2502fc3ff8b4143d8a0658e11"
+  integrity sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==
 
 eslint-config-react-app@^6.0.0:
   version "6.0.0"
@@ -7354,6 +7716,28 @@ eslint-plugin-react@^7.21.5, eslint-plugin-react@^7.22.0:
     prop-types "^15.7.2"
     resolve "^2.0.0-next.3"
     string.prototype.matchall "^4.0.5"
+
+eslint-plugin-react@^7.31.10:
+  version "7.33.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.33.2.tgz#69ee09443ffc583927eafe86ffebb470ee737608"
+  integrity sha512-73QQMKALArI8/7xGLNI/3LylrEYrlKZSb5C9+q3OtOewTnMQi5cT+aE9E41sLCmli3I9PGGmD1yiZydyo4FEPw==
+  dependencies:
+    array-includes "^3.1.6"
+    array.prototype.flatmap "^1.3.1"
+    array.prototype.tosorted "^1.1.1"
+    doctrine "^2.1.0"
+    es-iterator-helpers "^1.0.12"
+    estraverse "^5.3.0"
+    jsx-ast-utils "^2.4.1 || ^3.0.0"
+    minimatch "^3.1.2"
+    object.entries "^1.1.6"
+    object.fromentries "^2.0.6"
+    object.hasown "^1.1.2"
+    object.values "^1.1.6"
+    prop-types "^15.8.1"
+    resolve "^2.0.0-next.4"
+    semver "^6.3.1"
+    string.prototype.matchall "^4.0.8"
 
 eslint-plugin-testing-library@^3.9.2:
   version "3.10.2"
@@ -7460,6 +7844,52 @@ eslint@^7.11.0, eslint@^7.18.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
+eslint@^7.32.0:
+  version "7.32.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.32.0.tgz#c6d328a14be3fb08c8d1d21e12c02fdb7a2a812d"
+  integrity sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==
+  dependencies:
+    "@babel/code-frame" "7.12.11"
+    "@eslint/eslintrc" "^0.4.3"
+    "@humanwhocodes/config-array" "^0.5.0"
+    ajv "^6.10.0"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.2"
+    debug "^4.0.1"
+    doctrine "^3.0.0"
+    enquirer "^2.3.5"
+    escape-string-regexp "^4.0.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^2.1.0"
+    eslint-visitor-keys "^2.0.0"
+    espree "^7.3.1"
+    esquery "^1.4.0"
+    esutils "^2.0.2"
+    fast-deep-equal "^3.1.3"
+    file-entry-cache "^6.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob-parent "^5.1.2"
+    globals "^13.6.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    is-glob "^4.0.0"
+    js-yaml "^3.13.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.4.1"
+    lodash.merge "^4.6.2"
+    minimatch "^3.0.4"
+    natural-compare "^1.4.0"
+    optionator "^0.9.1"
+    progress "^2.0.0"
+    regexpp "^3.1.0"
+    semver "^7.2.1"
+    strip-ansi "^6.0.0"
+    strip-json-comments "^3.1.0"
+    table "^6.0.9"
+    text-table "^0.2.0"
+    v8-compile-cache "^2.0.3"
+
 espree@^7.3.0, espree@^7.3.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.1.tgz#f2df330b752c6f55019f8bd89b7660039c1bbbb6"
@@ -7497,6 +7927,11 @@ estraverse@^5.1.0, estraverse@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
+
+estraverse@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
+  integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
 estree-to-babel@^3.1.0:
   version "3.2.1"
@@ -8013,7 +8448,7 @@ follow-redirects@^1.0.0, follow-redirects@^1.10.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.1.tgz#d9114ded0a1cfdd334e164e6662ad02bfd91ff43"
   integrity sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
 
-for-each@~0.3.3:
+for-each@^0.3.3, for-each@~0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
   integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
@@ -8208,10 +8643,25 @@ function-bind@^1.1.1, function-bind@~1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+function.prototype.name@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.5.tgz#cce0505fe1ffb80503e6f9e46cc64e46a12a9621"
+  integrity sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.19.0"
+    functions-have-names "^1.2.2"
+
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
+functions-have-names@^1.2.2, functions-have-names@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
+  integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -8253,6 +8703,16 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
     has "^1.0.3"
     has-symbols "^1.0.1"
 
+get-intrinsic@^1.1.3, get-intrinsic@^1.2.0, get-intrinsic@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.1.tgz#d295644fed4505fc9cde952c37ee12b477a83d82"
+  integrity sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-proto "^1.0.1"
+    has-symbols "^1.0.3"
+
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz#b5fde77f22cbe35f390b4e089922c50bce6ef664"
@@ -8291,6 +8751,14 @@ get-stream@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
+
+get-symbol-description@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/get-symbol-description/-/get-symbol-description-1.0.0.tgz#7fdb81c900101fbd564dd5f1a30af5aadc1e58d6"
+  integrity sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.1"
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -8419,6 +8887,13 @@ globals@^13.6.0, globals@^13.9.0:
   dependencies:
     type-fest "^0.20.2"
 
+globalthis@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/globalthis/-/globalthis-1.0.3.tgz#5852882a52b80dc301b0660273e1ed082f0b6ccf"
+  integrity sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==
+  dependencies:
+    define-properties "^1.1.3"
+
 globby@11.0.1:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.1.tgz#9a2bf107a068f3ffeabc49ad702c79ede8cfd357"
@@ -8462,6 +8937,13 @@ globule@^1.0.0:
     glob "~7.1.1"
     lodash "~4.17.10"
     minimatch "~3.0.2"
+
+gopd@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
+  integrity sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==
+  dependencies:
+    get-intrinsic "^1.1.3"
 
 got@^9.6.0:
   version "9.6.0"
@@ -8557,6 +9039,11 @@ has-bigints@^1.0.1:
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
   integrity sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
 
+has-bigints@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
+  integrity sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -8567,10 +9054,34 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
+has-property-descriptors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz#610708600606d36961ed04c196193b6a607fa861"
+  integrity sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==
+  dependencies:
+    get-intrinsic "^1.1.1"
+
+has-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-proto/-/has-proto-1.0.1.tgz#1885c1305538958aff469fef37937c22795408e0"
+  integrity sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==
+
 has-symbols@^1.0.1, has-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
   integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
+
+has-symbols@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
+  integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
+
+has-tostringtag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25"
+  integrity sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==
+  dependencies:
+    has-symbols "^1.0.2"
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -8882,6 +9393,11 @@ husky@^5.2.0:
   resolved "https://registry.yarnpkg.com/husky/-/husky-5.2.0.tgz#fc5e1c2300d34855d47de4753607d00943fc0802"
   integrity sha512-AM8T/auHXRBxlrfPVLKP6jt49GCM2Zz47m8G3FOMsLmTv8Dj/fKVWE0Rh2d4Qrvmy131xEsdQnb3OXRib67PGg==
 
+husky@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.4.tgz#242048245dc49c8fb1bf0cc7cfb98dd722531535"
+  integrity sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==
+
 hyperscript-html@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/hyperscript-html/-/hyperscript-html-2.0.0.tgz#02cc9ba3040853ed311d70bb30630cc73ccb0bbd"
@@ -9165,6 +9681,15 @@ internal-slot@^1.0.3:
     has "^1.0.3"
     side-channel "^1.0.4"
 
+internal-slot@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.5.tgz#f2a2ee21f668f8627a4667f309dc0f4fb6674986"
+  integrity sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==
+  dependencies:
+    get-intrinsic "^1.2.0"
+    has "^1.0.3"
+    side-channel "^1.0.4"
+
 into-stream@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-6.0.0.tgz#4bfc1244c0128224e18b8870e85b2de8e66c6702"
@@ -9232,6 +9757,15 @@ is-arguments@^1.0.4:
   dependencies:
     call-bind "^1.0.0"
 
+is-array-buffer@^3.0.1, is-array-buffer@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.2.tgz#f2653ced8412081638ecb0ebbd0c41c6e0aecbbe"
+  integrity sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.2.0"
+    is-typed-array "^1.1.10"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -9241,6 +9775,13 @@ is-arrayish@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
   integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
+
+is-async-function@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-async-function/-/is-async-function-2.0.0.tgz#8e4418efd3e5d3a6ebb0164c05ef5afb69aa9646"
+  integrity sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==
+  dependencies:
+    has-tostringtag "^1.0.0"
 
 is-bigint@^1.0.1:
   version "1.0.2"
@@ -9278,6 +9819,11 @@ is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.3:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.3.tgz#8b1e0500b73a1d76c70487636f368e519de8db8e"
   integrity sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==
 
+is-callable@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
+  integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
+
 is-ci@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
@@ -9311,6 +9857,13 @@ is-core-module@^2.0.0, is-core-module@^2.2.0, is-core-module@^2.4.0:
   dependencies:
     has "^1.0.3"
 
+is-core-module@^2.9.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.13.0.tgz#bb52aa6e2cbd49a30c2ba68c42bf3435ba6072db"
+  integrity sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==
+  dependencies:
+    has "^1.0.3"
+
 is-data-descriptor@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
@@ -9329,6 +9882,13 @@ is-date-object@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.4.tgz#550cfcc03afada05eea3dd30981c7b09551f73e5"
   integrity sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==
+
+is-date-object@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.5.tgz#0841d5536e724c25597bf6ea62e1bd38298df31f"
+  integrity sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==
+  dependencies:
+    has-tostringtag "^1.0.0"
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -9375,6 +9935,13 @@ is-extglob@^2.1.0, is-extglob@^2.1.1:
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
 
+is-finalizationregistry@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-finalizationregistry/-/is-finalizationregistry-1.0.2.tgz#c8749b65f17c133313e661b1289b95ad3dbd62e6"
+  integrity sha512-0by5vtUJs8iFQb5TYUHHPudOR+qXYIMKtiUzvLIZITZUjknFmziyBJuLhVRc+Ds0dREFlskDNJKYIdIzu/9pfw==
+  dependencies:
+    call-bind "^1.0.2"
+
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
@@ -9396,6 +9963,13 @@ is-generator-fn@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
+
+is-generator-function@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.10.tgz#f1558baf1ac17e0deea7c0415c438351ff2b3c72"
+  integrity sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==
+  dependencies:
+    has-tostringtag "^1.0.0"
 
 is-glob@^3.1.0:
   version "3.1.0"
@@ -9424,6 +9998,11 @@ is-lambda@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-lambda/-/is-lambda-1.0.1.tgz#3d9877899e6a53efc0160504cde15f82e6f061d5"
   integrity sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=
 
+is-map@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.2.tgz#00922db8c9bf73e81b7a335827bc2a43f2b91127"
+  integrity sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==
+
 is-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
@@ -9438,6 +10017,11 @@ is-negative-zero@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.1.tgz#3de746c18dda2319241a53675908d8f766f11c24"
   integrity sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==
+
+is-negative-zero@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.2.tgz#7bf6f03a28003b8b3965de3ac26f664d765f3150"
+  integrity sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==
 
 is-npm@^3.0.0:
   version "3.0.0"
@@ -9532,6 +10116,14 @@ is-regex@^1.0.4, is-regex@^1.1.3:
     call-bind "^1.0.2"
     has-symbols "^1.0.2"
 
+is-regex@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
+  integrity sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
+
 is-regex@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.5.tgz#39d589a358bf18967f726967120b8fc1aed74eae"
@@ -9561,6 +10153,18 @@ is-root@2.1.0:
   resolved "https://registry.yarnpkg.com/is-root/-/is-root-2.1.0.tgz#809e18129cf1129644302a4f8544035d51984a9c"
   integrity sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg==
 
+is-set@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.2.tgz#90755fa4c2562dc1c5d4024760d6119b94ca18ec"
+  integrity sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==
+
+is-shared-array-buffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz#8f259c573b60b6a32d4058a1a07430c0a7344c79"
+  integrity sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==
+  dependencies:
+    call-bind "^1.0.2"
+
 is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
@@ -9576,6 +10180,13 @@ is-string@^1.0.5, is-string@^1.0.6:
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.6.tgz#3fe5d5992fb0d93404f32584d4b0179a71b54a5f"
   integrity sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==
 
+is-string@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.7.tgz#0dd12bf2006f255bb58f695110eff7491eebc0fd"
+  integrity sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==
+  dependencies:
+    has-tostringtag "^1.0.0"
+
 is-symbol@^1.0.2, is-symbol@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.4.tgz#a6dac93b635b063ca6872236de88910a57af139c"
@@ -9589,6 +10200,13 @@ is-text-path@^1.0.1:
   integrity sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=
   dependencies:
     text-extensions "^1.0.0"
+
+is-typed-array@^1.1.10, is-typed-array@^1.1.9:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.12.tgz#d0bab5686ef4a76f7a73097b95470ab199c57d4a"
+  integrity sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==
+  dependencies:
+    which-typed-array "^1.1.11"
 
 is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
@@ -9611,6 +10229,26 @@ is-valid-glob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-valid-glob/-/is-valid-glob-1.0.0.tgz#29bf3eff701be2d4d315dbacc39bc39fe8f601aa"
   integrity sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=
+
+is-weakmap@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-weakmap/-/is-weakmap-2.0.1.tgz#5008b59bdc43b698201d18f62b37b2ca243e8cf2"
+  integrity sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==
+
+is-weakref@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2"
+  integrity sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==
+  dependencies:
+    call-bind "^1.0.2"
+
+is-weakset@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-weakset/-/is-weakset-2.0.2.tgz#4569d67a747a1ce5a994dfd4ef6dcea76e7c0a1d"
+  integrity sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.1"
 
 is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
@@ -9638,6 +10276,11 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
+
+isarray@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
+  integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
 
 isbinaryfile@^4.0.4:
   version "4.0.8"
@@ -9717,6 +10360,17 @@ istanbul-reports@^3.0.2:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
+
+iterator.prototype@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/iterator.prototype/-/iterator.prototype-1.1.0.tgz#690c88b043d821f783843aaf725d7ac3b62e3b46"
+  integrity sha512-rjuhAk1AJ1fssphHD0IFV6TWL40CwRZ53FrztKx43yk2v6rguBYsY4Bj1VU4HmoMmKwZUlx7mfnhDf9cOp4YTw==
+  dependencies:
+    define-properties "^1.1.4"
+    get-intrinsic "^1.1.3"
+    has-symbols "^1.0.3"
+    has-tostringtag "^1.0.0"
+    reflect.getprototypeof "^1.0.3"
 
 jake@^10.6.1:
   version "10.8.2"
@@ -11686,6 +12340,13 @@ minimatch@3.0.4, minimatch@^3.0.2, minimatch@^3.0.4, minimatch@~3.0.2:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimist-options@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-4.1.0.tgz#c0655713c53a8a2ebd77ffa247d342c40f010619"
@@ -12404,6 +13065,11 @@ object-inspect@^1.10.3, object-inspect@^1.9.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.10.3.tgz#c2aa7d2d09f50c99375704f7a0adf24c5782d369"
   integrity sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==
 
+object-inspect@^1.12.3:
+  version "1.12.3"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.3.tgz#ba62dffd67ee256c8c086dfae69e016cd1f198b9"
+  integrity sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==
+
 object-inspect@~1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.7.0.tgz#f4f6bd181ad77f006b5ece60bd0b6f398ff74a67"
@@ -12444,6 +13110,16 @@ object.assign@^4.0.4, object.assign@^4.1.0, object.assign@^4.1.2:
     has-symbols "^1.0.1"
     object-keys "^1.1.1"
 
+object.assign@^4.1.4:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.4.tgz#9673c7c7c351ab8c4d0b516f4343ebf4dfb7799f"
+  integrity sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    has-symbols "^1.0.3"
+    object-keys "^1.1.1"
+
 object.entries@^1.1.0, object.entries@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.4.tgz#43ccf9a50bc5fd5b649d45ab1a579f24e088cafd"
@@ -12452,6 +13128,15 @@ object.entries@^1.1.0, object.entries@^1.1.4:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
     es-abstract "^1.18.2"
+
+object.entries@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.6.tgz#9737d0e5b8291edd340a3e3264bb8a3b00d5fa23"
+  integrity sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
 
 object.fromentries@^2.0.4:
   version "2.0.4"
@@ -12463,6 +13148,15 @@ object.fromentries@^2.0.4:
     es-abstract "^1.18.0-next.2"
     has "^1.0.3"
 
+object.fromentries@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.6.tgz#cdb04da08c539cffa912dcd368b886e0904bfa73"
+  integrity sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+
 object.getownpropertydescriptors@^2.0.3, object.getownpropertydescriptors@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.2.tgz#1bd63aeacf0d5d2d2f31b5e393b03a7c601a23f7"
@@ -12471,6 +13165,14 @@ object.getownpropertydescriptors@^2.0.3, object.getownpropertydescriptors@^2.1.0
     call-bind "^1.0.2"
     define-properties "^1.1.3"
     es-abstract "^1.18.0-next.2"
+
+object.hasown@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/object.hasown/-/object.hasown-1.1.2.tgz#f919e21fad4eb38a57bc6345b3afd496515c3f92"
+  integrity sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==
+  dependencies:
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
 
 object.pick@^1.3.0:
   version "1.3.0"
@@ -12487,6 +13189,15 @@ object.values@^1.1.0, object.values@^1.1.3, object.values@^1.1.4:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
     es-abstract "^1.18.2"
+
+object.values@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.6.tgz#4abbaa71eba47d63589d402856f908243eea9b1d"
+  integrity sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
 
 oblivious-set@1.0.0:
   version "1.0.0"
@@ -12907,7 +13618,7 @@ path-key@^3.0.0, path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-parse@^1.0.6:
+path-parse@^1.0.6, path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
@@ -13748,6 +14459,11 @@ prettier@^2.2.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
   integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
 
+prettier@^2.4.1:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+
 pretty-bytes@^5.3.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"
@@ -13862,6 +14578,15 @@ prop-types@^15.6.2, prop-types@^15.7.2:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.8.1"
+
+prop-types@^15.8.1:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.13.1"
 
 proxy-addr@~2.0.5:
   version "2.0.7"
@@ -14134,7 +14859,7 @@ react-final-form@^6.5.3:
   dependencies:
     "@babel/runtime" "^7.12.1"
 
-react-is@^16.8.1:
+react-is@^16.13.1, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -14416,6 +15141,18 @@ reduce-without@^1.0.1:
   dependencies:
     test-value "^2.0.0"
 
+reflect.getprototypeof@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/reflect.getprototypeof/-/reflect.getprototypeof-1.0.3.tgz#2738fd896fcc3477ffbd4190b40c2458026b6928"
+  integrity sha512-TTAOZpkJ2YLxl7mVHWrNo3iDMEkYlva/kgFcXndqMgbo/AZUmmavEkdXV+hXtE4P8xdyEKRzalaFqZVuwIk/Nw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+    get-intrinsic "^1.1.1"
+    globalthis "^1.0.3"
+    which-builtin-type "^1.1.3"
+
 regenerate-unicode-properties@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz#e5de7111d655e7ba60c057dbe9ff37c87e65cdec"
@@ -14465,6 +15202,15 @@ regexp.prototype.flags@^1.2.0, regexp.prototype.flags@^1.3.1:
   dependencies:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
+
+regexp.prototype.flags@^1.4.3, regexp.prototype.flags@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz#fe7ce25e7e4cca8db37b6634c8a2c7009199b9cb"
+  integrity sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.2.0"
+    functions-have-names "^1.2.3"
 
 regexpp@^3.1.0:
   version "3.2.0"
@@ -14718,6 +15464,15 @@ resolve@^2.0.0-next.3:
     is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
+resolve@^2.0.0-next.4:
+  version "2.0.0-next.4"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-2.0.0-next.4.tgz#3d37a113d6429f496ec4752d2a2e58efb1fd4660"
+  integrity sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==
+  dependencies:
+    is-core-module "^2.9.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
 resolve@~1.17.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
@@ -14902,6 +15657,16 @@ rxjs@^6.6.0:
   dependencies:
     tslib "^1.9.0"
 
+safe-array-concat@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/safe-array-concat/-/safe-array-concat-1.0.0.tgz#2064223cba3c08d2ee05148eedbc563cd6d84060"
+  integrity sha512-9dVEFruWIsnie89yym+xWTAYASdpw3CJV7Li/6zBewGf9z2i1j31rP6jnY0pHEO4QZh6N0K11bFjWmdR8UGdPQ==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.2.0"
+    has-symbols "^1.0.3"
+    isarray "^2.0.5"
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -14911,6 +15676,15 @@ safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1,
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safe-regex-test@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/safe-regex-test/-/safe-regex-test-1.0.0.tgz#793b874d524eb3640d1873aad03596db2d4f2295"
+  integrity sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.3"
+    is-regex "^1.1.4"
 
 safe-regex@^1.1.0:
   version "1.1.0"
@@ -15082,17 +15856,22 @@ semver@7.3.2:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
-semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
-  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@^7.1.1, semver@^7.1.2, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
+semver@7.3.5, semver@^7.1.1, semver@^7.1.2, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
 send@0.17.1, send@latest:
   version "0.17.1"
@@ -15744,6 +16523,29 @@ string.prototype.matchall@^4.0.5:
     regexp.prototype.flags "^1.3.1"
     side-channel "^1.0.4"
 
+string.prototype.matchall@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz#3bf85722021816dcd1bf38bb714915887ca79fd3"
+  integrity sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+    get-intrinsic "^1.1.3"
+    has-symbols "^1.0.3"
+    internal-slot "^1.0.3"
+    regexp.prototype.flags "^1.4.3"
+    side-channel "^1.0.4"
+
+string.prototype.trim@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz#a68352740859f6893f14ce3ef1bb3037f7a90533"
+  integrity sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+
 string.prototype.trim@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.4.tgz#6014689baf5efaf106ad031a5fa45157666ed1bd"
@@ -15761,6 +16563,15 @@ string.prototype.trimend@^1.0.4:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
+string.prototype.trimend@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz#c4a27fa026d979d79c04f17397f250a462944533"
+  integrity sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+
 string.prototype.trimstart@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz#b36399af4ab2999b4c9c648bd7a3fb2bb26feeed"
@@ -15768,6 +16579,15 @@ string.prototype.trimstart@^1.0.4:
   dependencies:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
+
+string.prototype.trimstart@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz#e90ab66aa8e4007d92ef591bbf3cd422c56bdcf4"
+  integrity sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
 
 string_decoder@^1.0.0, string_decoder@^1.1.1:
   version "1.3.0"
@@ -15951,6 +16771,11 @@ supports-hyperlinks@^2.0.0, supports-hyperlinks@^2.1.0:
   dependencies:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
+
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
 svg-parser@^2.0.2:
   version "2.0.4"
@@ -16583,6 +17408,45 @@ type@^2.0.0:
   resolved "https://registry.yarnpkg.com/type/-/type-2.5.0.tgz#0a2e78c2e77907b252abe5f298c1b01c63f0db3d"
   integrity sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw==
 
+typed-array-buffer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz#18de3e7ed7974b0a729d3feecb94338d1472cd60"
+  integrity sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.2.1"
+    is-typed-array "^1.1.10"
+
+typed-array-byte-length@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/typed-array-byte-length/-/typed-array-byte-length-1.0.0.tgz#d787a24a995711611fb2b87a4052799517b230d0"
+  integrity sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==
+  dependencies:
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    has-proto "^1.0.1"
+    is-typed-array "^1.1.10"
+
+typed-array-byte-offset@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/typed-array-byte-offset/-/typed-array-byte-offset-1.0.0.tgz#cbbe89b51fdef9cd6aaf07ad4707340abbc4ea0b"
+  integrity sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    has-proto "^1.0.1"
+    is-typed-array "^1.1.10"
+
+typed-array-length@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/typed-array-length/-/typed-array-length-1.0.4.tgz#89d83785e5c4098bec72e08b319651f0eac9c1bb"
+  integrity sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==
+  dependencies:
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    is-typed-array "^1.1.9"
+
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
@@ -16633,6 +17497,16 @@ unbox-primitive@^1.0.1:
     function-bind "^1.1.1"
     has-bigints "^1.0.1"
     has-symbols "^1.0.2"
+    which-boxed-primitive "^1.0.2"
+
+unbox-primitive@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.2.tgz#29032021057d5e6cdbd08c5129c226dff8ed6f9e"
+  integrity sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==
+  dependencies:
+    call-bind "^1.0.2"
+    has-bigints "^1.0.2"
+    has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
 
 unc-path-regex@^0.1.2:
@@ -17079,8 +17953,10 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
+    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
+    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"
@@ -17322,10 +18198,49 @@ which-boxed-primitive@^1.0.2:
     is-string "^1.0.5"
     is-symbol "^1.0.3"
 
+which-builtin-type@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/which-builtin-type/-/which-builtin-type-1.1.3.tgz#b1b8443707cc58b6e9bf98d32110ff0c2cbd029b"
+  integrity sha512-YmjsSMDBYsM1CaFiayOVT06+KJeXf0o5M/CAd4o1lTadFAtacTUM49zoYxr/oroopFDfhvN6iEcBxUyc3gvKmw==
+  dependencies:
+    function.prototype.name "^1.1.5"
+    has-tostringtag "^1.0.0"
+    is-async-function "^2.0.0"
+    is-date-object "^1.0.5"
+    is-finalizationregistry "^1.0.2"
+    is-generator-function "^1.0.10"
+    is-regex "^1.1.4"
+    is-weakref "^1.0.2"
+    isarray "^2.0.5"
+    which-boxed-primitive "^1.0.2"
+    which-collection "^1.0.1"
+    which-typed-array "^1.1.9"
+
+which-collection@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/which-collection/-/which-collection-1.0.1.tgz#70eab71ebbbd2aefaf32f917082fc62cdcb70906"
+  integrity sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==
+  dependencies:
+    is-map "^2.0.1"
+    is-set "^2.0.1"
+    is-weakmap "^2.0.1"
+    is-weakset "^2.0.1"
+
 which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
+
+which-typed-array@^1.1.10, which-typed-array@^1.1.11, which-typed-array@^1.1.9:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.11.tgz#99d691f23c72aab6768680805a271b69761ed61a"
+  integrity sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    gopd "^1.0.1"
+    has-tostringtag "^1.0.0"
 
 which@^1.2.9, which@^1.3.1:
   version "1.3.1"


### PR DESCRIPTION
Also upgrades `cli-utils-docsite` with a minor bump that fixes titles in the docs.

For this PR I ran the following commands:
```bash
yarn upgrade @dhis2/cli-utils-docsite --latest
yarn upgrade @dhis2/cli-style --latest
prettier . -w
eslint ./packages --fix
```
And I fixed the import statements with added `.js` where needed, and a single import needed to be changed to have `index.js` added to the path (packages/utils/src/cmds/schema/diff/index.js)

### package.json override
Furthermore I added this to package.json to let the code be runnable on a arm device (such as my mac m1)

``` json
"resolutions": {
        "@ls-lint/ls-lint": "2.0.1"
}
```