### PR TITLE
ci: ping netlify to rebuild on change

### DIFF
--- a/.github/workflows/rebuild-docs.yml
+++ b/.github/workflows/rebuild-docs.yml
@@ -1,0 +1,20 @@
+name: 'rebuild developer docs'
+
+on:
+    push:
+        branches:
+            - master
+        paths:
+            - 'docs/**'
+
+concurrency:
+    group: ${{ github.workflow}}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    publish-docs:
+        runs-on: ubuntu-latest
+        steps:
+            - run: curl -X POST -d {} https://api.netlify.com/build_hooks/"$NETLIFY_DEVELOPER_DOCS_TOKEN"
+              env:
+                  NETLIFY_DEVELOPER_DOCS_TOKEN: ${{ secrets.NETLIFY_DEVELOPER_DOCS_TOKEN }}


### PR DESCRIPTION
Todo:

- [x] Only rebuild when files related to the docs change
- [x] Add `NETLIFY_DEVELOPER_DOCS_TOKEN` to repo secrets
- [ ] Add to remaining repos: cli-style, app-platform, app-runtime, cli-utils-cypress

Links:

- https://app.netlify.com/sites/dhis2-developer-portal/overview
- https://github.com/dhis2/developer-portal/
- https://docs.netlify.com/configure-builds/build-hooks/
- https://github.com/dhis2/developer-portal/blob/main/docs-migrate.js
- https://github.com/orgs/community/discussions/27027
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore