### PR TITLE
fix(deps): set react resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
         }
     },
     "resolutions": {
-        "@ls-lint/ls-lint": "2.0.1"
+        "@ls-lint/ls-lint": "2.0.1",
+        "react": "16.14.0",
+        "react-dom": "16.14.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -28,8 +28,6 @@
         }
     },
     "resolutions": {
-        "@ls-lint/ls-lint": "2.0.1",
-        "react": "16.14.0",
-        "react-dom": "16.14.0"
+        "@ls-lint/ls-lint": "2.0.1"
     }
 }

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -22,6 +22,10 @@
         "envinfo": "^7.5.0",
         "inquirer": "^7.1.0"
     },
+    "resolutions": {
+        "react": "16.14.0",
+        "react-dom": "16.14.0"
+    },
     "bin": {
         "d2": "bin/d2"
     },


### PR DESCRIPTION
After the previous change in https://github.com/dhis2/cli/pull/619, there is still an infinite loop, but it looks different.

One hypothesis is that there is still a circular dependency causing this, which could be between the app-platform and UI, as mentioned in the platform DevEx meeting. Another hypothesis is that a failure to resolve a dependency could cause the infinite loop, which is [mentioned in an NPM bug report](https://github.com/npm/cli/issues/3385#issuecomment-880263350). The last time, it could have been a failure to resolve a `@dhis2/cli-app-scripts` version; this time, it could be a failure to resolve a `react` and `react-dom` version -- here's some logs that make me think so:

```
2383 silly placeDep node_modules/@dhis2/cli react-dom@16.14.0 OK for: @dhis2/app-runtime@3.10.4-alpha.1 want: ^16.8.6
2384 silly placeDep node_modules/@dhis2/cli react@16.14.0 REPLACE for: react-dom@16.14.0 want: ^16.14.0
....
2455 silly placeDep node_modules/@dhis2/cli react@16.8.6 REPLACE for: @dhis2/multi-calendar-dates@1.0.2 want: 16.8
2456 silly placeDep ROOT react-dom@16.8.6 OK for: @dhis2/multi-calendar-dates@1.0.2 want: 16.8
2457 silly placeDep ROOT react@16.8.6 OK for: react-dom@16.8.6 want: ^16.0.0
```

My hope is that setting a resolution field for a specific `react` and `react-dom` version will override the conflicting dependency requirements 🤞 