### PR TITLE
docs(create-app): document community templates

### DIFF
--- a/docs/commands/create-app.md
+++ b/docs/commands/create-app.md
@@ -52,13 +52,13 @@ You can run `pnpm create @dhis2/app@alpha --help` for the list of options availa
 
 The CLI also supports installing templates developed by the community using a GitHub repository URL or `owner/repo` specifier. These templates are maintained outside the CLI, so you should review the source code before using them in your project.
 
-Here is a good starting template developed by the community:
+Here are some of the available community templates:
 
 ### Tailwind + React Router
 
 React Router DHIS2 app template with Tailwind CSS.
 
-Repository: <https://github.com/derrick-nuby/dhis2-ts-tailwind-react-router>
+Repository: [https://github.com/derrick-nuby/dhis2-ts-tailwind-react-router](https://github.com/derrick-nuby/dhis2-ts-tailwind-react-router)
 
 ```sh
 pnpm create @dhis2/app my-app --template https://github.com/derrick-nuby/dhis2-ts-tailwind-react-router
@@ -66,7 +66,12 @@ pnpm create @dhis2/app my-app --template https://github.com/derrick-nuby/dhis2-t
 
 Main components: Tailwind CSS, React Router
 Organisation: HISP Rwanda
-Developed by: Derrick Iradukunda
+Developed by: [Derrick Iradukunda](https://github.com/derrick-nuby)
+
+If you would like to promote your own community template, you can open a PR
+for the [CLI docs](https://github.com/dhis2/cli/blob/master/docs/commands/create-app.md)
+including template URL and installation steps, and any other relevant
+information.
 
 ## Examples
 

--- a/docs/commands/create-app.md
+++ b/docs/commands/create-app.md
@@ -68,10 +68,7 @@ Main components: Tailwind CSS, React Router
 Organisation: HISP Rwanda
 Developed by: [Derrick Iradukunda](https://github.com/derrick-nuby)
 
-If you would like to promote your own community template, you can open a PR
-for the [CLI docs](https://github.com/dhis2/cli/blob/master/docs/commands/create-app.md)
-including template URL and installation steps, and any other relevant
-information.
+If you would like to promote your own community template, you can open a PR for the [CLI docs](https://github.com/dhis2/cli/blob/master/docs/commands/create-app.md) including template URL and installation steps, and any other relevant information.
 
 ## Examples
 

--- a/docs/commands/create-app.md
+++ b/docs/commands/create-app.md
@@ -48,6 +48,26 @@ You can run `pnpm create @dhis2/app@alpha --help` for the list of options availa
   --packagemanager                                                      [string]
 ```
 
+## Community templates
+
+The CLI also supports installing templates developed by the community using a GitHub repository URL or `owner/repo` specifier. These templates are maintained outside the CLI, so you should review the source code before using them in your project.
+
+Here is a good starting template developed by the community:
+
+### Tailwind + React Router
+
+React Router DHIS2 app template with Tailwind CSS.
+
+Repository: <https://github.com/derrick-nuby/dhis2-ts-tailwind-react-router>
+
+```sh
+pnpm create @dhis2/app my-app --template https://github.com/derrick-nuby/dhis2-ts-tailwind-react-router
+```
+
+Main components: Tailwind CSS, React Router
+Organisation: HISP Rwanda
+Developed by: Derrick Iradukunda
+
 ## Examples
 
 Here are some examples of how you can use the CLI

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,11 +60,11 @@ importers:
   packages/main:
     dependencies:
       '@dhis2/cli-app':
-        specifier: 5.3.1
-        version: 5.3.1(typescript@5.8.3)
+        specifier: 5.4.0
+        version: 5.4.0(@types/babel__core@7.20.5)(@types/node@24.0.4)(react@18.3.1)(terser@5.43.1)(type-fest@4.41.0)(typescript@5.8.3)(webpack-dev-server@4.15.2(webpack@5.100.0))
       '@dhis2/cli-cluster':
-        specifier: 5.3.1
-        version: 5.3.1
+        specifier: 5.4.0
+        version: 5.4.0
       '@dhis2/cli-helpers-engine':
         specifier: ^3.2.1
         version: 3.2.2
@@ -72,8 +72,8 @@ importers:
         specifier: ^10.7.9
         version: 10.7.9
       '@dhis2/cli-utils':
-        specifier: 5.3.1
-        version: 5.3.1(typescript@5.8.3)
+        specifier: 5.4.0
+        version: 5.4.0(typescript@5.8.3)
       cli-table3:
         specifier: ^0.6.0
         version: 0.6.5
@@ -1370,13 +1370,13 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
-  '@dhis2/cli-app@5.3.1':
-    resolution: {integrity: sha512-BZHliDwvDWxgfnSdreDI+DV2EDMPB/rZhsYBRxm1qfZ65+y/uGPPJAT17gq0iH3Vu6vs2r4hmfN9VMbdWZK/jA==}
+  '@dhis2/cli-app@5.4.0':
+    resolution: {integrity: sha512-u7uOvZkWqDprcLwote3vS3fr8y9QkQjjzhPs7bIEDEdWMpUJfvQz4axuH1TKPta6I2Xv4xwwwQq3MBH3ad8d/Q==}
     engines: {node: '>=12'}
     hasBin: true
 
-  '@dhis2/cli-cluster@5.3.1':
-    resolution: {integrity: sha512-8carthbPbITkwCPwtS731MoIh3twuvot6LzWztKRWOAziEnrwO9ceD8Mfjar2ulG+pysJDSATR1sT63AwUP7Ow==}
+  '@dhis2/cli-cluster@5.4.0':
+    resolution: {integrity: sha512-0uScwwUl0JZOUzFvqqJcRiqtWuvgsUlrMfRMLZoIMQKSnOtmYI3z7s5BLIO5JKkYnMHoDS0N0LoR9oh99kKuew==}
     engines: {node: '>=12'}
     hasBin: true
 
@@ -1415,8 +1415,8 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
-  '@dhis2/cli-utils@5.3.1':
-    resolution: {integrity: sha512-jEkhvU+0hmGi6kcUvGh/s0+xLezGqj4z3RygwvyEJcGi7NyheLeEZ2NZ+hlUD/t1a655sWqrosmW1FVKxSoGnA==}
+  '@dhis2/cli-utils@5.4.0':
+    resolution: {integrity: sha512-DqJhb/DzXx4/k8ChEEsQDxhExseHa3GtUX8CS/YnAm++UpPlk3b6+lhNOLB0xDxaBobgltLBRLr9W6tuXRrFbQ==}
     engines: {node: '>=12'}
     hasBin: true
 
@@ -5492,6 +5492,7 @@ packages:
     resolution: {integrity: sha512-t0etAxTUk1w5MYdNOkZBZ8rvYYN5iL+2dHCCx/DpkFm/bW28M6y5nUS83D4XdZiHy35Fpaw6LBb+F88fHZnVCw==}
     engines: {node: '>=8.17.0'}
     hasBin: true
+    bundledDependencies: []
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -10736,7 +10737,7 @@ snapshots:
       '@dhis2/cli-helpers-engine': 3.2.2
       '@jest/core': 27.5.1
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.11.0)(type-fest@4.41.0)(webpack-dev-server@4.15.2(webpack@5.100.0))(webpack@5.100.0)
-      '@vitejs/plugin-react': 4.6.0(vite@5.4.19)
+      '@vitejs/plugin-react': 4.6.0(vite@5.4.19(@types/node@24.0.4)(terser@5.43.1))
       '@yarnpkg/lockfile': 1.1.0
       archiver: 7.0.1
       axios: 0.25.0
@@ -10803,7 +10804,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@dhis2/cli-app@5.3.1(typescript@5.8.3)':
+  '@dhis2/cli-app@5.4.0(@types/babel__core@7.20.5)(@types/node@24.0.4)(react@18.3.1)(terser@5.43.1)(type-fest@4.41.0)(typescript@5.8.3)(webpack-dev-server@4.15.2(webpack@5.100.0))':
     dependencies:
       '@dhis2/cli-app-scripts': 12.11.0-alpha.1(@types/babel__core@7.20.5)(@types/node@24.0.4)(react@18.3.1)(terser@5.43.1)(type-fest@4.41.0)(typescript@5.8.3)(webpack-dev-server@4.15.2(webpack@5.100.0))
       '@dhis2/cli-helpers-engine': 3.2.2
@@ -10839,7 +10840,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@dhis2/cli-cluster@5.3.1':
+  '@dhis2/cli-cluster@5.4.0':
     dependencies:
       '@dhis2/cli-helpers-engine': 3.2.2
       cli-table3: 0.6.5
@@ -10959,7 +10960,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@dhis2/cli-utils@5.3.1(typescript@5.8.3)':
+  '@dhis2/cli-utils@5.4.0(typescript@5.8.3)':
     dependencies:
       '@dhis2/cli-helpers-engine': 3.2.2
       '@dhis2/cli-utils-codemods': 3.0.0(@babel/preset-env@7.28.0(@babel/core@7.27.7))
@@ -12239,7 +12240,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@4.6.0(vite@5.4.19)':
+  '@vitejs/plugin-react@4.6.0(vite@5.4.19(@types/node@24.0.4)(terser@5.43.1))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.0)


### PR DESCRIPTION
# Summary

This PR updates the `create-app` documentation to highlight community
templates that can be installed directly from GitHub.

## What Changed

1. Added a `Community templates` section to `docs/commands/create-app.md`.
2. Documented the Tailwind + React Router template as a recommended starting point.
3. Added the template repository URL and a direct install command using the existing Git template support.
4. Added guidance to review community template source code before use.